### PR TITLE
feat: accept a user-chosen strong password on registration

### DIFF
--- a/src/modules/user/application/UserRegister.ts
+++ b/src/modules/user/application/UserRegister.ts
@@ -2,7 +2,9 @@ import { UserProfileRole } from "src/evolution-types/src/types/UserProfileRole";
 import { EmailSender } from "../../../shared/email/domain/EmailSender";
 import { ConflictError } from "../../../shared/errors/ConflictError";
 import { Hash } from "../../../shared/Hash";
+import { JWT } from "../../../shared/JWT";
 import { Logger } from "../../../shared/logger/domain/Logger";
+import { SecurePassword } from "../domain/SecurePassword";
 import { User } from "../domain/User";
 import { UserRepository } from "../domain/UserRepository";
 
@@ -12,9 +14,10 @@ export class UserRegister {
 		private readonly hash: Hash,
 		private readonly logger: Logger,
 		private readonly emailSender: EmailSender,
+		private readonly jwt: JWT,
 	) { }
 
-	async register({ id, email, username }: { id: string; email: string; username: string }): Promise<unknown> {
+	async register({ id, email, username, password }: { id: string; email: string; username: string; password?: string }): Promise<unknown> {
 		this.logger.info(`Creating new user ${email}`);
 
 		const existingUser = await this.repository.findByEmailOrUsername(email, username);
@@ -23,20 +26,86 @@ export class UserRegister {
 			throw new ConflictError(`User with email ${email} or username ${username} already exists`);
 		}
 
-		const password = this.passwordGenerator(4);
-		this.logger.debug(`Password generate for email ${email} is ${password}`);
-		const passwordHashed = await this.hash.hash(password);
+		// Every account always gets a 4-char game password so it can connect through other ygopro clients.
+		const gamePassword = this.passwordGenerator(4);
+		const gamePasswordHashed = await this.hash.hash(gamePassword);
 
-		const user = User.create({ id, email, username, password: passwordHashed, role: UserProfileRole.USER });
+		if (password) {
+			return this.registerWithSecurePassword({ id, email, username, password, gamePasswordHashed });
+		}
+
+		return this.registerWithGamePassword({ id, email, username, gamePassword, gamePasswordHashed });
+	}
+
+	private async registerWithSecurePassword({
+		id,
+		email,
+		username,
+		password,
+		gamePasswordHashed,
+	}: {
+		id: string;
+		email: string;
+		username: string;
+		password: string;
+		gamePasswordHashed: string;
+	}): Promise<{ id: string; username: string; email: string; token: string }> {
+		const securePassword = SecurePassword.create(password);
+		const securePasswordHashed = await this.hash.hash(securePassword.value);
+
+		const user = User.create({
+			id,
+			email,
+			username,
+			password: gamePasswordHashed,
+			securePassword: securePasswordHashed,
+			role: UserProfileRole.USER,
+		});
 
 		await this.repository.create(user);
 
 		const emailData = {
 			username,
-			password,
 			subject: "Welcome to Evolution YGO",
-			html: `<p>Welcome ${username}, your password is ${password}</p>`,
-			text: `Welcome ${username}, your password is ${password}`,
+			html: `<p>Welcome ${username}!</p>`,
+			text: `Welcome ${username}!`,
+		};
+
+		this.emailSender.send(user.email, emailData).catch((error: Error) => {
+			this.logger.error(`Error sending email to ${email}`);
+			this.logger.error(error);
+		});
+
+		const token = this.jwt.generate({ id: user.id, role: user.role });
+
+		return { id: user.id, username: user.username, email: user.email, token };
+	}
+
+	private async registerWithGamePassword({
+		id,
+		email,
+		username,
+		gamePassword,
+		gamePasswordHashed,
+	}: {
+		id: string;
+		email: string;
+		username: string;
+		gamePassword: string;
+		gamePasswordHashed: string;
+	}): Promise<{ id: string; username: string; email: string }> {
+		this.logger.debug(`Password generate for email ${email} is ${gamePassword}`);
+
+		const user = User.create({ id, email, username, password: gamePasswordHashed, role: UserProfileRole.USER });
+
+		await this.repository.create(user);
+
+		const emailData = {
+			username,
+			password: gamePassword,
+			subject: "Welcome to Evolution YGO",
+			html: `<p>Welcome ${username}, your password is ${gamePassword}</p>`,
+			text: `Welcome ${username}, your password is ${gamePassword}`,
 		};
 
 		this.emailSender.send(user.email, emailData).catch((error: Error) => {

--- a/src/modules/user/domain/SecurePassword.ts
+++ b/src/modules/user/domain/SecurePassword.ts
@@ -1,0 +1,19 @@
+import { InvalidArgumentError } from "../../../shared/errors/InvalidArgumentError";
+
+export class SecurePassword {
+	private constructor(public readonly value: string) {}
+
+	static create(value: string): SecurePassword {
+		if (value.length < 8) {
+			throw new InvalidArgumentError("the password must be at least 8 characters long");
+		}
+		if (!/[a-zA-Z]/.test(value)) {
+			throw new InvalidArgumentError("the password must contain at least one letter");
+		}
+		if (!/\d/.test(value)) {
+			throw new InvalidArgumentError("the password must contain at least one number");
+		}
+
+		return new SecurePassword(value);
+	}
+}

--- a/src/modules/user/domain/User.ts
+++ b/src/modules/user/domain/User.ts
@@ -5,6 +5,7 @@ export class User {
 	public readonly id: string;
 	public readonly email: string;
 	public readonly password: string;
+	public readonly securePassword: string | null;
 	private _username: string;
 	public readonly role: UserProfileRole;
 	public participantId: string | null;
@@ -14,6 +15,7 @@ export class User {
 		username,
 		email,
 		password,
+		securePassword,
 		role,
 		participantId,
 	}: {
@@ -21,6 +23,7 @@ export class User {
 		username: string;
 		email: string;
 		password: string;
+		securePassword: string | null;
 		role: UserProfileRole;
 		participantId: string | null;
 	}) {
@@ -28,6 +31,7 @@ export class User {
 		this._username = username;
 		this.email = email;
 		this.password = password;
+		this.securePassword = securePassword;
 		this.role = role;
 		this.participantId = participantId;
 	}
@@ -37,12 +41,14 @@ export class User {
 		username,
 		email,
 		password,
+		securePassword,
 		role,
 	}: {
 		id: string;
 		username: string;
 		email: string;
 		password: string;
+		securePassword?: string | null;
 		role: UserProfileRole;
 	}): User {
 		if (!username.trim()) {
@@ -57,10 +63,18 @@ export class User {
 		if (!password.trim()) {
 			throw new InvalidArgumentError(`password cannot be empty`);
 		}
-		return new User({ id, username, email, password, role, participantId: null });
+		return new User({ id, username, email, password, securePassword: securePassword ?? null, role, participantId: null });
 	}
 
-	static from(data: { id: string; username: string; password: string; email: string; role: UserProfileRole; participantId: string | null }): User {
+	static from(data: {
+		id: string;
+		username: string;
+		password: string;
+		securePassword: string | null;
+		email: string;
+		role: UserProfileRole;
+		participantId: string | null;
+	}): User {
 		return new User(data);
 	}
 
@@ -85,6 +99,7 @@ export class User {
 			id: this.id,
 			username: this.username,
 			password,
+			securePassword: this.securePassword,
 			email: this.email,
 			role: this.role,
 			participantId: this.participantId,

--- a/src/modules/user/infrastructure/UserPostgresRepository.ts
+++ b/src/modules/user/infrastructure/UserPostgresRepository.ts
@@ -23,6 +23,7 @@ export class UserPostgresRepository implements UserRepository {
 			id: user.id,
 			username: user.username,
 			password: user.password,
+			securePassword: user.securePassword,
 			email: user.email,
 		});
 		await repository.save(userProfileEntity);
@@ -66,6 +67,7 @@ export class UserPostgresRepository implements UserRepository {
 			username: user.username,
 			email: user.email,
 			password: user.password,
+			securePassword: user.securePassword,
 		});
 
 		await repository.save(updatedUserProfileEntity);

--- a/src/server/routes/user-router.ts
+++ b/src/server/routes/user-router.ts
@@ -44,7 +44,7 @@ export const userRouter = new Elysia({ prefix: "/users" })
 		"/register",
 		async ({ body }) => {
 			const id = randomUUID();
-			return new UserRegister(userRepository, hash, logger, emailSender).register({ ...body, id });
+			return new UserRegister(userRepository, hash, logger, emailSender, jwt).register({ ...body, id });
 		},
 		{
 			detail: {
@@ -70,6 +70,7 @@ export const userRouter = new Elysia({ prefix: "/users" })
 			body: t.Object({
 				username: t.String({ minLength: 1, maxLength: 14, pattern: '^.*\\S.*$' }),
 				email: t.String({ minLength: 1, pattern: '^.*\\S.*$' }),
+				password: t.Optional(t.String({ minLength: 1, pattern: '^.*\\S.*$' })),
 			}),
 		},
 	)

--- a/tests/unit/modules/users/application/UserRegister.test.ts
+++ b/tests/unit/modules/users/application/UserRegister.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 import { UserRegister } from "../../../../../src/modules/user/application/UserRegister";
+import { User } from "../../../../../src/modules/user/domain/User";
 import { UserRepository } from "../../../../../src/modules/user/domain/UserRepository";
 import { EmailSender } from "../../../../../src/shared/email/domain/EmailSender";
 import { ConflictError } from "../../../../../src/shared/errors/ConflictError";
+import { InvalidArgumentError } from "../../../../../src/shared/errors/InvalidArgumentError";
 import { Hash } from "../../../../../src/shared/Hash";
+import { JWT } from "../../../../../src/shared/JWT";
 import { Logger } from "../../../../../src/shared/logger/domain/Logger";
 import { Pino } from "../../../../../src/shared/logger/infrastructure/Pino";
 import { UserMother } from "../mothers/UserMother";
@@ -15,6 +18,7 @@ describe("UserRegister", () => {
 	let hash: Hash;
 	let logger: Logger;
 	let emailSender: EmailSender;
+	let jwt: JWT;
 	let userRegister: UserRegister;
 	let request: { id: string; email: string; username: string };
 
@@ -27,28 +31,62 @@ describe("UserRegister", () => {
 			update: async () => undefined,
 			updateParticipantId: async () => undefined,
 			findByParticipantId: async () => null,
-		}
+		};
 		hash = new Hash();
 		logger = new Pino();
 		emailSender = {
-			send: async () => undefined
-		}
-		userRegister = new UserRegister(repository, hash, logger, emailSender);
+			send: async () => undefined,
+		};
+		jwt = new JWT({ issuer: "evolution", secret: "test-secret" });
+		userRegister = new UserRegister(repository, hash, logger, emailSender, jwt);
 		request = UserRegisterRequestMother.create();
 
 		spyOn(emailSender, "send").mockResolvedValue();
 		spyOn(repository, "findByEmailOrUsername").mockResolvedValue(null);
 	});
 
-	it("Should register an user correctly", async () => {
+	it("registers a user with only a game password when no account password is provided", async () => {
 		const repositoryCreateSpy = spyOn(repository, "create");
 		const emailSenderSendSpy = spyOn(emailSender, "send");
-		await userRegister.register(request);
+
+		const result = await userRegister.register(request);
+
 		expect(repositoryCreateSpy).toHaveBeenCalledTimes(1);
 		expect(emailSenderSendSpy).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({ id: request.id, username: request.username, email: request.email });
+
+		const createdUser = repositoryCreateSpy.mock.calls[0][0] as User;
+		expect(createdUser.securePassword).toBeNull();
 	});
 
-	it("Should should error if user register already exists", async () => {
+	it("registers a new user with a chosen strong password and returns a token", async () => {
+		const repositoryCreateSpy = spyOn(repository, "create");
+
+		const result = (await userRegister.register({ ...request, password: "yugi2024" })) as { token: string };
+
+		const createdUser = repositoryCreateSpy.mock.calls[0][0] as User;
+		expect(typeof createdUser.securePassword).toBe("string");
+		expect(createdUser.securePassword).not.toBe("yugi2024"); // stored hashed, never plaintext
+		expect(typeof createdUser.password).toBe("string"); // 4-char game password still provisioned
+		expect(typeof result.token).toBe("string");
+		expect(result.token.length).toBeGreaterThan(0);
+	});
+
+	it("does not email the plaintext password on the strong-password flow", async () => {
+		const emailSenderSendSpy = spyOn(emailSender, "send");
+
+		await userRegister.register({ ...request, password: "yugi2024" });
+
+		const emailData = emailSenderSendSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+		expect(emailData?.password).toBeUndefined();
+		expect(JSON.stringify(emailData ?? {})).not.toContain("yugi2024");
+	});
+
+	it("rejects a weak password that does not meet the policy", async () => {
+		expect(userRegister.register({ ...request, password: "weak" })).rejects.toThrow(InvalidArgumentError);
+	});
+
+	it("errors if the user already exists", async () => {
 		spyOn(repository, "findByEmailOrUsername").mockResolvedValue(UserMother.create());
 		expect(userRegister.register(request)).rejects.toThrow(
 			new ConflictError(`User with email ${request.email} or username ${request.username} already exists`),

--- a/tests/unit/modules/users/domain/SecurePassword.test.ts
+++ b/tests/unit/modules/users/domain/SecurePassword.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+
+import { SecurePassword } from "../../../../../src/modules/user/domain/SecurePassword";
+import { InvalidArgumentError } from "../../../../../src/shared/errors/InvalidArgumentError";
+
+describe("SecurePassword", () => {
+	it("creates a valid secure password and exposes its value", () => {
+		const password = SecurePassword.create("yugi2024");
+
+		expect(password.value).toBe("yugi2024");
+	});
+
+	it("throws when shorter than 8 characters", () => {
+		expect(() => SecurePassword.create("yugi24")).toThrow(InvalidArgumentError);
+	});
+
+	it("throws when it has no letter", () => {
+		expect(() => SecurePassword.create("12345678")).toThrow(InvalidArgumentError);
+	});
+
+	it("throws when it has no digit", () => {
+		expect(() => SecurePassword.create("password")).toThrow(InvalidArgumentError);
+	});
+});

--- a/tests/unit/modules/users/domain/User.test.ts
+++ b/tests/unit/modules/users/domain/User.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { UserProfileRole } from "src/evolution-types/src/types/UserProfileRole";
+
+import { User } from "../../../../../src/modules/user/domain/User";
+
+describe("User", () => {
+	it("creates a user carrying a secure password", () => {
+		const user = User.create({
+			id: "a-user-id",
+			username: "player",
+			email: "player@evolution.com",
+			password: "hashed-game-password",
+			securePassword: "hashed-secure-password",
+			role: UserProfileRole.USER,
+		});
+
+		expect(user.securePassword).toBe("hashed-secure-password");
+	});
+
+	it("defaults secure password to null when not provided", () => {
+		const user = User.create({
+			id: "a-user-id",
+			username: "player",
+			email: "player@evolution.com",
+			password: "hashed-game-password",
+			role: UserProfileRole.USER,
+		});
+
+		expect(user.securePassword).toBeNull();
+	});
+
+	it("preserves the secure password when the game password is updated", () => {
+		const user = User.create({
+			id: "a-user-id",
+			username: "player",
+			email: "player@evolution.com",
+			password: "hashed-game-password",
+			securePassword: "hashed-secure-password",
+			role: UserProfileRole.USER,
+		});
+
+		const updated = user.updatePassword("new-hashed-game-password");
+
+		expect(updated.securePassword).toBe("hashed-secure-password");
+	});
+});

--- a/tests/unit/modules/users/mothers/UserMother.ts
+++ b/tests/unit/modules/users/mothers/UserMother.ts
@@ -10,6 +10,7 @@ export class UserMother {
 			username: faker.internet.username(),
 			email: faker.internet.email(),
 			password: faker.internet.password(),
+			securePassword: null,
 			role: UserProfileRole.USER,
 			participantId: null,
 			...params,


### PR DESCRIPTION
## Summary
Registration now optionally accepts a strong password chosen by the user, in addition to the existing flow.

- With a `password` in the body: it is validated against a minimum policy (at least 8 characters, with one letter and one number), stored hashed in `secure_password`, and the response returns a JWT.
- A 4-character game password is still provisioned for every account, so it keeps working on other ygopro clients.
- Without a `password`: registration behaves exactly as before — existing callers are unaffected.
- The strong-password flow never emails the chosen password.

## Changes
| File | Change |
|------|--------|
| `src/modules/user/domain/SecurePassword.ts` | New value object that enforces the password policy |
| `src/modules/user/domain/User.ts` | Carries `securePassword` (nullable) |
| `src/modules/user/application/UserRegister.ts` | Branches the strong-password and game-password flows |
| `src/modules/user/infrastructure/UserPostgresRepository.ts` | Persists `securePassword` |
| `src/server/routes/user-router.ts` | `password` is now an optional body field |

## Test Plan
- [x] `bun test` — all green
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files