### PR TITLE
feat: add endpoint to regenerate the game password

### DIFF
--- a/src/modules/user/application/UserGamePasswordGenerator.ts
+++ b/src/modules/user/application/UserGamePasswordGenerator.ts
@@ -1,0 +1,26 @@
+import { NotFoundError } from "../../../shared/errors/NotFoundError";
+import { Hash } from "../../../shared/Hash";
+import { GamePassword } from "../domain/GamePassword";
+import { UserRepository } from "../domain/UserRepository";
+
+export class UserGamePasswordGenerator {
+	constructor(
+		private readonly repository: UserRepository,
+		private readonly hash: Hash,
+	) {}
+
+	async generate({ userId }: { userId: string }): Promise<{ gamePassword: string }> {
+		const user = await this.repository.findById(userId);
+
+		if (!user) {
+			throw new NotFoundError(`User with id ${userId} not found`);
+		}
+
+		const gamePassword = GamePassword.generate();
+		const gamePasswordHashed = await this.hash.hash(gamePassword.value);
+
+		await this.repository.update(user.updatePassword(gamePasswordHashed));
+
+		return { gamePassword: gamePassword.value };
+	}
+}

--- a/src/modules/user/application/UserRegister.ts
+++ b/src/modules/user/application/UserRegister.ts
@@ -4,6 +4,7 @@ import { ConflictError } from "../../../shared/errors/ConflictError";
 import { Hash } from "../../../shared/Hash";
 import { JWT } from "../../../shared/JWT";
 import { Logger } from "../../../shared/logger/domain/Logger";
+import { GamePassword } from "../domain/GamePassword";
 import { SecurePassword } from "../domain/SecurePassword";
 import { User } from "../domain/User";
 import { UserRepository } from "../domain/UserRepository";
@@ -27,14 +28,14 @@ export class UserRegister {
 		}
 
 		// Every account always gets a 4-char game password so it can connect through other ygopro clients.
-		const gamePassword = this.passwordGenerator(4);
-		const gamePasswordHashed = await this.hash.hash(gamePassword);
+		const gamePassword = GamePassword.generate();
+		const gamePasswordHashed = await this.hash.hash(gamePassword.value);
 
 		if (password) {
 			return this.registerWithSecurePassword({ id, email, username, password, gamePasswordHashed });
 		}
 
-		return this.registerWithGamePassword({ id, email, username, gamePassword, gamePasswordHashed });
+		return this.registerWithGamePassword({ id, email, username, gamePassword: gamePassword.value, gamePasswordHashed });
 	}
 
 	private async registerWithSecurePassword({
@@ -115,15 +116,4 @@ export class UserRegister {
 
 		return user.toJson();
 	}
-
-	private readonly passwordGenerator = (length: number) => {
-		const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-		let password = "";
-		for (let i = 0; i < length; i++) {
-			const randomIndex = Math.floor(Math.random() * charset.length);
-			password += charset.charAt(randomIndex);
-		}
-
-		return password;
-	};
 }

--- a/src/modules/user/domain/GamePassword.ts
+++ b/src/modules/user/domain/GamePassword.ts
@@ -1,0 +1,16 @@
+export class GamePassword {
+	private static readonly LENGTH = 4;
+	private static readonly CHARSET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+	private constructor(public readonly value: string) {}
+
+	static generate(): GamePassword {
+		let value = "";
+		for (let i = 0; i < GamePassword.LENGTH; i++) {
+			const randomIndex = Math.floor(Math.random() * GamePassword.CHARSET.length);
+			value += GamePassword.CHARSET.charAt(randomIndex);
+		}
+
+		return new GamePassword(value);
+	}
+}

--- a/src/server/routes/user-router.ts
+++ b/src/server/routes/user-router.ts
@@ -11,6 +11,7 @@ import { UserStatsPostgresRepository } from "../../modules/stats/infrastructure/
 import { UserForgotPassword } from "../../modules/user/application/UserForgotPassword";
 import { UserPasswordReset } from "../../modules/user/application/UserPasswordReset";
 import { UserPasswordUpdater } from "../../modules/user/application/UserPasswordUpdater";
+import { UserGamePasswordGenerator } from "../../modules/user/application/UserGamePasswordGenerator";
 import { UserRegister } from "../../modules/user/application/UserRegister";
 import { UserTokenValidator } from "../../modules/user/application/UserTokenValidator";
 import { UserUsernameUpdater } from "../../modules/user/application/UserUsernameUpdater";
@@ -356,6 +357,32 @@ export const userRouter = new Elysia({ prefix: "/users" })
 					body: t.Object({
 						username: t.String({ minLength: 1, maxLength: 14, pattern: '^.*\\S.*$' }),
 					}),
+				},
+			)
+			.post(
+				"/game-password",
+				async ({ bearer }) => {
+					const { id } = jwt.decode(bearer as string) as { id: string };
+					return new UserGamePasswordGenerator(userRepository, hash).generate({ userId: id });
+				},
+				{
+					detail: {
+						tags: ['User Management'],
+						summary: 'Generate game password',
+						description: 'Regenerates the 4-character game password used to connect through other ygopro clients and returns it once',
+						security: [{ bearerAuth: [] }],
+						responses: {
+							200: {
+								description: 'Game password generated successfully',
+								content: {
+									'application/json': {
+										example: { gamePassword: 'Xy3z' }
+									}
+								}
+							},
+							404: { description: 'User not found' }
+						}
+					},
 				},
 			)
 	)

--- a/tests/unit/modules/users/application/UserGamePasswordGenerator.test.ts
+++ b/tests/unit/modules/users/application/UserGamePasswordGenerator.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+import { UserGamePasswordGenerator } from "../../../../../src/modules/user/application/UserGamePasswordGenerator";
+import { User } from "../../../../../src/modules/user/domain/User";
+import { UserRepository } from "../../../../../src/modules/user/domain/UserRepository";
+import { NotFoundError } from "../../../../../src/shared/errors/NotFoundError";
+import { Hash } from "../../../../../src/shared/Hash";
+import { UserMother } from "../mothers/UserMother";
+
+describe("UserGamePasswordGenerator", () => {
+	let repository: UserRepository;
+	let hash: Hash;
+	let generator: UserGamePasswordGenerator;
+
+	beforeEach(() => {
+		repository = {
+			create: async () => undefined,
+			findByEmailOrUsername: async () => null,
+			findByEmail: async () => null,
+			findById: async () => null,
+			update: async () => undefined,
+			updateParticipantId: async () => undefined,
+			findByParticipantId: async () => null,
+		};
+		hash = new Hash();
+		generator = new UserGamePasswordGenerator(repository, hash);
+	});
+
+	it("regenerates a 4-character game password, persists it and returns the plaintext once", async () => {
+		const user = UserMother.create({ securePassword: "kept-account-password-hash" });
+		spyOn(repository, "findById").mockResolvedValue(user);
+		const updateSpy = spyOn(repository, "update");
+
+		const result = await generator.generate({ userId: user.id });
+
+		expect(result.gamePassword).toMatch(/^[a-zA-Z0-9]{4}$/);
+		expect(updateSpy).toHaveBeenCalledTimes(1);
+
+		const updatedUser = updateSpy.mock.calls[0][0] as User;
+		expect(updatedUser.securePassword).toBe("kept-account-password-hash"); // account password untouched
+		expect(updatedUser.password).not.toBe(user.password); // game password rotated
+		expect(await hash.compare(result.gamePassword, updatedUser.password)).toBe(true); // returned plaintext matches stored hash
+	});
+
+	it("throws when the user does not exist", async () => {
+		spyOn(repository, "findById").mockResolvedValue(null);
+
+		expect(generator.generate({ userId: "missing-user-id" })).rejects.toThrow(NotFoundError);
+	});
+});

--- a/tests/unit/modules/users/domain/GamePassword.test.ts
+++ b/tests/unit/modules/users/domain/GamePassword.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+
+import { GamePassword } from "../../../../../src/modules/user/domain/GamePassword";
+
+describe("GamePassword", () => {
+	it("generates a 4-character value from the allowed charset", () => {
+		const gamePassword = GamePassword.generate();
+
+		expect(gamePassword.value).toMatch(/^[a-zA-Z0-9]{4}$/);
+	});
+
+	it("generates a different value on each call (not a constant)", () => {
+		const values = new Set(Array.from({ length: 20 }, () => GamePassword.generate().value));
+
+		expect(values.size).toBeGreaterThan(1);
+	});
+});


### PR DESCRIPTION
## Summary
Adds an authenticated `POST /users/game-password` endpoint that rotates the 4-character game password used to connect through other ygopro clients, returning the new value once. The account password is left untouched.

It also centralizes the game-password generation in a single `GamePassword` value object, which registration now reuses instead of its own generator.

## Changes
| File | Change |
|------|--------|
| `src/modules/user/domain/GamePassword.ts` | New value object that generates a 4-char value |
| `src/modules/user/application/UserGamePasswordGenerator.ts` | Use case: rotates and persists the game password, preserving the account password |
| `src/modules/user/application/UserRegister.ts` | Reuses `GamePassword.generate()` (removes the duplicated generator) |
| `src/server/routes/user-router.ts` | New authenticated `POST /users/game-password` |

## Test Plan
- [x] `bun test` — all green
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files