### PR TITLE
feat: validate login against the account password with a migration fallback

### DIFF
--- a/src/modules/auth/application/UserAuth.ts
+++ b/src/modules/auth/application/UserAuth.ts
@@ -16,24 +16,27 @@ export class UserAuth {
 	}: {
 		email: string;
 		password: string;
-	}): Promise<{ token: string; username: string; id: string; }> {
+	}): Promise<{ token: string; username: string; id: string; mustUpgrade: boolean }> {
 		const user = await this.userRepository.findByEmail(email);
 		if (!user) {
 			throw new AuthenticationError("Wrong email or password");
 		}
 
-		const isCorrectPassword = await this.hash.compare(password, user.password);
+		// Primary credential: the account password (strong, set through the new client).
+		if (user.securePassword && (await this.hash.compare(password, user.securePassword))) {
+			const token = this.jwt.generate({ id: user.id, role: user.role });
 
-		if (!isCorrectPassword) {
-			throw new AuthenticationError("Wrong email or password");
+			return { id: user.id, token, username: user.username, mustUpgrade: false };
 		}
 
-		const token = this.jwt.generate({ id: user.id, role: user.role });
+		// Fallback: the 4-char game password, only while the user has not set an account password yet.
+		// Once migrated, the weak game password no longer grants API access.
+		if (!user.securePassword && (await this.hash.compare(password, user.password))) {
+			const token = this.jwt.generate({ id: user.id, role: user.role, mustUpgrade: true });
 
-		return {
-			id: user.id,
-			token,
-			username: user.username,
-		};
+			return { id: user.id, token, username: user.username, mustUpgrade: true };
+		}
+
+		throw new AuthenticationError("Wrong email or password");
 	}
 }

--- a/tests/unit/modules/auth/application/UserAuth.test.ts
+++ b/tests/unit/modules/auth/application/UserAuth.test.ts
@@ -50,6 +50,44 @@ describe("UserAuth", () => {
     expect(response).toHaveProperty("id", user.id);
   });
 
+  it("logs in a user that has not migrated yet with the game password and flags mustUpgrade", async () => {
+    // user from beforeEach has no account password (securePassword null) and a game password.
+    spyOn(repository, "findByEmail").mockResolvedValue(user);
+
+    const response = await userAuth.login(request);
+
+    expect(response).toHaveProperty("token");
+    expect(response).toHaveProperty("mustUpgrade", true);
+  });
+
+  it("logs in a migrated user with the account password and does not require an upgrade", async () => {
+    const accountPassword = "BlueEyes7";
+    const migratedUser = UserMother.create({
+      email: request.email,
+      securePassword: await hash.hash(accountPassword),
+    });
+    spyOn(repository, "findByEmail").mockResolvedValue(migratedUser);
+
+    const response = await userAuth.login({ email: request.email, password: accountPassword });
+
+    expect(response).toHaveProperty("token");
+    expect(response).toHaveProperty("mustUpgrade", false);
+  });
+
+  it("rejects the game password once the user has an account password", async () => {
+    const gamePassword = "ab12";
+    const migratedUser = UserMother.create({
+      email: request.email,
+      password: await hash.hash(gamePassword),
+      securePassword: await hash.hash("StrongPass1"),
+    });
+    spyOn(repository, "findByEmail").mockResolvedValue(migratedUser);
+
+    await expect(userAuth.login({ email: request.email, password: gamePassword })).rejects.toThrowError(
+      new AuthenticationError("Wrong email or password"),
+    );
+  });
+
   it("Should throw an AuthenticationError if user does not exist", async () => {
     spyOn(repository, "findByEmail").mockResolvedValue(null);
 


### PR DESCRIPTION
## Summary
Login now validates the account password first, with a fallback for users that haven't set one yet.

- The account password (set through the new client) is checked first.
- A user that hasn't set an account password can still sign in with their game password; the response sets `mustUpgrade: true` so the client can prompt them to choose one.
- Once an account password exists, the 4-character game password no longer grants API access — only the account password does.

## Changes
| File | Change |
|------|--------|
| `src/modules/auth/application/UserAuth.ts` | Account-password-first login with a gated game-password fallback and a `mustUpgrade` flag |

## Test Plan
- [x] `bun test` — all green
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files