### PR TITLE
feat: add endpoint to set the account password (upgrade)

### DIFF
--- a/src/modules/user/application/UserUpgradePassword.ts
+++ b/src/modules/user/application/UserUpgradePassword.ts
@@ -1,0 +1,41 @@
+import { ConflictError } from "../../../shared/errors/ConflictError";
+import { NotFoundError } from "../../../shared/errors/NotFoundError";
+import { Hash } from "../../../shared/Hash";
+import { JWT } from "../../../shared/JWT";
+import { SecurePassword } from "../domain/SecurePassword";
+import { UserRepository } from "../domain/UserRepository";
+
+export class UserUpgradePassword {
+	constructor(
+		private readonly repository: UserRepository,
+		private readonly hash: Hash,
+		private readonly jwt: JWT,
+	) {}
+
+	async upgrade({
+		userId,
+		password,
+	}: {
+		userId: string;
+		password: string;
+	}): Promise<{ id: string; token: string; username: string }> {
+		const user = await this.repository.findById(userId);
+		if (!user) {
+			throw new NotFoundError(`User with id ${userId} not found`);
+		}
+
+		if (user.securePassword) {
+			throw new ConflictError("User already has an account password");
+		}
+
+		const securePassword = SecurePassword.create(password);
+		const securePasswordHashed = await this.hash.hash(securePassword.value);
+
+		const upgradedUser = user.updateSecurePassword(securePasswordHashed);
+		await this.repository.update(upgradedUser);
+
+		const token = this.jwt.generate({ id: upgradedUser.id, role: upgradedUser.role });
+
+		return { id: upgradedUser.id, token, username: upgradedUser.username };
+	}
+}

--- a/src/modules/user/domain/User.ts
+++ b/src/modules/user/domain/User.ts
@@ -106,6 +106,22 @@ export class User {
 		});
 	}
 
+	updateSecurePassword(securePassword: string): User {
+		if (!securePassword) {
+			throw new InvalidArgumentError(`secure password cannot be empty`);
+		}
+
+		return new User({
+			id: this.id,
+			username: this.username,
+			password: this.password,
+			securePassword,
+			email: this.email,
+			role: this.role,
+			participantId: this.participantId,
+		});
+	}
+
 	updateUsername(username: string): void {
 		if (!username.trim()) {
 			throw new InvalidArgumentError(`username cannot be empty`);

--- a/src/server/routes/user-router.ts
+++ b/src/server/routes/user-router.ts
@@ -13,6 +13,7 @@ import { UserPasswordReset } from "../../modules/user/application/UserPasswordRe
 import { UserPasswordUpdater } from "../../modules/user/application/UserPasswordUpdater";
 import { UserGamePasswordGenerator } from "../../modules/user/application/UserGamePasswordGenerator";
 import { UserRegister } from "../../modules/user/application/UserRegister";
+import { UserUpgradePassword } from "../../modules/user/application/UserUpgradePassword";
 import { UserTokenValidator } from "../../modules/user/application/UserTokenValidator";
 import { UserUsernameUpdater } from "../../modules/user/application/UserUsernameUpdater";
 import { UserPostgresRepository } from "../../modules/user/infrastructure/UserPostgresRepository";
@@ -383,6 +384,32 @@ export const userRouter = new Elysia({ prefix: "/users" })
 							404: { description: 'User not found' }
 						}
 					},
+				},
+			)
+			.post(
+				"/upgrade-password",
+				async ({ body, bearer }) => {
+					const { id } = jwt.decode(bearer as string) as { id: string };
+					return new UserUpgradePassword(userRepository, hash, jwt).upgrade({
+						...(body as { password: string }),
+						userId: id,
+					});
+				},
+				{
+					detail: {
+						tags: ['Authentication'],
+						summary: 'Set account password (upgrade)',
+						description: 'Sets the strong account password for a user that signed in with mustUpgrade, and returns a fresh token',
+						security: [{ bearerAuth: [] }],
+						responses: {
+							200: { description: 'Account password set successfully' },
+							400: { description: 'Password does not meet the policy' },
+							409: { description: 'User already has an account password' }
+						}
+					},
+					body: t.Object({
+						password: t.String({ minLength: 1 }),
+					}),
 				},
 			)
 	)

--- a/tests/unit/modules/users/application/UserUpgradePassword.test.ts
+++ b/tests/unit/modules/users/application/UserUpgradePassword.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+import { UserUpgradePassword } from "../../../../../src/modules/user/application/UserUpgradePassword";
+import { User } from "../../../../../src/modules/user/domain/User";
+import { UserRepository } from "../../../../../src/modules/user/domain/UserRepository";
+import { ConflictError } from "../../../../../src/shared/errors/ConflictError";
+import { InvalidArgumentError } from "../../../../../src/shared/errors/InvalidArgumentError";
+import { NotFoundError } from "../../../../../src/shared/errors/NotFoundError";
+import { Hash } from "../../../../../src/shared/Hash";
+import { JWT } from "../../../../../src/shared/JWT";
+import { UserMother } from "../mothers/UserMother";
+
+describe("UserUpgradePassword", () => {
+	let repository: UserRepository;
+	let hash: Hash;
+	let jwt: JWT;
+	let upgrader: UserUpgradePassword;
+
+	beforeEach(() => {
+		repository = {
+			create: async () => undefined,
+			findByEmailOrUsername: async () => null,
+			findByEmail: async () => null,
+			findById: async () => null,
+			update: async () => undefined,
+			updateParticipantId: async () => undefined,
+			findByParticipantId: async () => null,
+		};
+		hash = new Hash();
+		jwt = new JWT({ issuer: "issuer", secret: "secret" });
+		upgrader = new UserUpgradePassword(repository, hash, jwt);
+	});
+
+	it("sets the account password for a user that has not migrated yet and returns a token", async () => {
+		const user = UserMother.create({ securePassword: null });
+		spyOn(repository, "findById").mockResolvedValue(user);
+		const updateSpy = spyOn(repository, "update");
+
+		const result = await upgrader.upgrade({ userId: user.id, password: "yugi2024" });
+
+		expect(updateSpy).toHaveBeenCalledTimes(1);
+		const updatedUser = updateSpy.mock.calls[0][0] as User;
+		expect(updatedUser.securePassword).not.toBeNull();
+		expect(await hash.compare("yugi2024", updatedUser.securePassword as string)).toBe(true);
+		expect(typeof result.token).toBe("string");
+		expect(result.token.length).toBeGreaterThan(0);
+	});
+
+	it("rejects the upgrade when the user already has an account password", async () => {
+		const migratedUser = UserMother.create({ securePassword: "already-an-account-password-hash" });
+		spyOn(repository, "findById").mockResolvedValue(migratedUser);
+		const updateSpy = spyOn(repository, "update");
+
+		expect(upgrader.upgrade({ userId: migratedUser.id, password: "yugi2024" })).rejects.toThrow(ConflictError);
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
+	it("rejects a weak account password", async () => {
+		const user = UserMother.create({ securePassword: null });
+		spyOn(repository, "findById").mockResolvedValue(user);
+
+		expect(upgrader.upgrade({ userId: user.id, password: "weak" })).rejects.toThrow(InvalidArgumentError);
+	});
+
+	it("throws when the user does not exist", async () => {
+		spyOn(repository, "findById").mockResolvedValue(null);
+
+		expect(upgrader.upgrade({ userId: "missing-user-id", password: "yugi2024" })).rejects.toThrow(NotFoundError);
+	});
+});

--- a/tests/unit/modules/users/domain/User.test.ts
+++ b/tests/unit/modules/users/domain/User.test.ts
@@ -43,4 +43,20 @@ describe("User", () => {
 
 		expect(updated.securePassword).toBe("hashed-secure-password");
 	});
+
+	it("sets the secure password when upgrading and preserves the rest", () => {
+		const user = User.create({
+			id: "a-user-id",
+			username: "player",
+			email: "player@evolution.com",
+			password: "hashed-game-password",
+			role: UserProfileRole.USER,
+		});
+
+		const upgraded = user.updateSecurePassword("hashed-account-password");
+
+		expect(upgraded.securePassword).toBe("hashed-account-password");
+		expect(upgraded.password).toBe(user.password);
+		expect(upgraded.username).toBe(user.username);
+	});
 });


### PR DESCRIPTION
## Summary
Adds an authenticated `POST /users/upgrade-password` endpoint so a user that signed in with `mustUpgrade` can set their strong account password.

- Validates the password policy, stores it hashed in `secure_password`, and returns a fresh token.
- A user that already has an account password is rejected (`409`) — this endpoint only sets it the first time. Changing an existing one is a separate concern.

## Changes
| File | Change |
|------|--------|
| `src/modules/user/domain/User.ts` | New `updateSecurePassword` that returns a user with the account password set |
| `src/modules/user/application/UserUpgradePassword.ts` | Use case: validates, sets the account password, returns a token |
| `src/server/routes/user-router.ts` | New authenticated `POST /users/upgrade-password` |

## Test Plan
- [x] `bun test` — all green
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files