### PR TITLE
feat: add account password change and reset endpoints

### DIFF
--- a/src/modules/user/application/UserAccountPasswordReset.ts
+++ b/src/modules/user/application/UserAccountPasswordReset.ts
@@ -1,0 +1,46 @@
+import { EmailSender } from "../../../shared/email/domain/EmailSender";
+import { AuthenticationError } from "../../../shared/errors/AuthenticationError";
+import { NotFoundError } from "../../../shared/errors/NotFoundError";
+import { Hash } from "../../../shared/Hash";
+import { JWT } from "../../../shared/JWT";
+import { Logger } from "../../../shared/logger/domain/Logger";
+import { SecurePassword } from "../domain/SecurePassword";
+import { UserRepository } from "../domain/UserRepository";
+
+export class UserAccountPasswordReset {
+	constructor(
+		private readonly repository: UserRepository,
+		private readonly hash: Hash,
+		private readonly emailSender: EmailSender,
+		private readonly logger: Logger,
+		private readonly jwt: JWT,
+	) {}
+
+	async resetPassword({ token, newPassword }: { token: string; newPassword: string }): Promise<void> {
+		if (!token) {
+			throw new AuthenticationError("No token provided");
+		}
+
+		const decoded = this.jwt.decode(token) as { id: string };
+		const user = await this.repository.findById(decoded.id);
+		if (!user) {
+			this.logger.error(`User not found for account password reset: ${decoded.id}`);
+			throw new NotFoundError("User not found");
+		}
+
+		const securePassword = SecurePassword.create(newPassword);
+		const securePasswordHashed = await this.hash.hash(securePassword.value);
+
+		await this.repository.update(user.updateSecurePassword(securePasswordHashed));
+		this.logger.info(`Account password reset for user: ${user.id}`);
+
+		const emailData = {
+			username: user.username,
+			subject: "Password Changed - Evolution YGO",
+			html: `<p>Hello ${user.username}! Your account password has been reset. If this wasn't you, contact support immediately.</p>`,
+			text: `Hello ${user.username}! Your account password has been reset. If this wasn't you, contact support immediately.`,
+		};
+
+		await this.emailSender.send(user.email, emailData);
+	}
+}

--- a/src/modules/user/application/UserAccountPasswordUpdater.ts
+++ b/src/modules/user/application/UserAccountPasswordUpdater.ts
@@ -1,0 +1,51 @@
+import { EmailSender } from "../../../shared/email/domain/EmailSender";
+import { AuthenticationError } from "../../../shared/errors/AuthenticationError";
+import { NotFoundError } from "../../../shared/errors/NotFoundError";
+import { Hash } from "../../../shared/Hash";
+import { Logger } from "../../../shared/logger/domain/Logger";
+import { SecurePassword } from "../domain/SecurePassword";
+import { UserRepository } from "../domain/UserRepository";
+
+export class UserAccountPasswordUpdater {
+	constructor(
+		private readonly repository: UserRepository,
+		private readonly hash: Hash,
+		private readonly logger: Logger,
+		private readonly emailSender: EmailSender,
+	) {}
+
+	async updatePassword({
+		id,
+		currentPassword,
+		newPassword,
+	}: {
+		id: string;
+		currentPassword: string;
+		newPassword: string;
+	}): Promise<void> {
+		const user = await this.repository.findById(id);
+		if (!user) {
+			throw new NotFoundError(`user with id ${id} not found`);
+		}
+
+		if (!user.securePassword || !(await this.hash.compare(currentPassword, user.securePassword))) {
+			this.logger.error(`Wrong account password for user: ${id}`);
+			throw new AuthenticationError("Wrong password");
+		}
+
+		const securePassword = SecurePassword.create(newPassword);
+		const securePasswordHashed = await this.hash.hash(securePassword.value);
+
+		await this.repository.update(user.updateSecurePassword(securePasswordHashed));
+		this.logger.info(`Account password updated for user: ${user.id}`);
+
+		const emailData = {
+			username: user.username,
+			subject: "Password Changed - Evolution YGO",
+			html: `<p>Hello ${user.username}! Your account password has been changed. If this wasn't you, contact support immediately.</p>`,
+			text: `Hello ${user.username}! Your account password has been changed. If this wasn't you, contact support immediately.`,
+		};
+
+		await this.emailSender.send(user.email, emailData);
+	}
+}

--- a/src/server/routes/user-router.ts
+++ b/src/server/routes/user-router.ts
@@ -13,6 +13,8 @@ import { UserPasswordReset } from "../../modules/user/application/UserPasswordRe
 import { UserPasswordUpdater } from "../../modules/user/application/UserPasswordUpdater";
 import { UserGamePasswordGenerator } from "../../modules/user/application/UserGamePasswordGenerator";
 import { UserRegister } from "../../modules/user/application/UserRegister";
+import { UserAccountPasswordReset } from "../../modules/user/application/UserAccountPasswordReset";
+import { UserAccountPasswordUpdater } from "../../modules/user/application/UserAccountPasswordUpdater";
 import { UserUpgradePassword } from "../../modules/user/application/UserUpgradePassword";
 import { UserTokenValidator } from "../../modules/user/application/UserTokenValidator";
 import { UserUsernameUpdater } from "../../modules/user/application/UserUsernameUpdater";
@@ -200,6 +202,35 @@ export const userRouter = new Elysia({ prefix: "/users" })
 			},
 			body: t.Object({
 				password: t.String({ minLength: 4, maxLength: 4, pattern: '^.*\\S.*$' }),
+			}),
+		},
+	)
+	.post(
+		"/reset-account-password",
+		async ({ body, headers }) => {
+			const token = headers.authorization?.replace("Bearer ", "");
+			if (!token) {
+				throw new AuthenticationError("No token provided");
+			}
+			return new UserAccountPasswordReset(userRepository, hash, emailSender, logger, jwt).resetPassword({
+				token,
+				newPassword: body.password,
+			});
+		},
+		{
+			detail: {
+				tags: ['Authentication'],
+				summary: 'Reset account password',
+				description: 'Resets the strong account password using a valid reset token',
+				security: [{ bearerAuth: [] }],
+				responses: {
+					200: { description: 'Account password reset successfully' },
+					400: { description: 'Password does not meet the policy' },
+					401: { description: 'Invalid or expired token' }
+				}
+			},
+			body: t.Object({
+				password: t.String({ minLength: 1 }),
 			}),
 		},
 	)
@@ -409,6 +440,33 @@ export const userRouter = new Elysia({ prefix: "/users" })
 					},
 					body: t.Object({
 						password: t.String({ minLength: 1 }),
+					}),
+				},
+			)
+			.post(
+				"/change-account-password",
+				async ({ body, bearer }) => {
+					const { id } = jwt.decode(bearer as string) as { id: string };
+					return new UserAccountPasswordUpdater(userRepository, hash, logger, emailSender).updatePassword({
+						...(body as { currentPassword: string; newPassword: string }),
+						id,
+					});
+				},
+				{
+					detail: {
+						tags: ['Authentication'],
+						summary: 'Change account password',
+						description: 'Changes the strong account password of the authenticated user, verifying the current one',
+						security: [{ bearerAuth: [] }],
+						responses: {
+							200: { description: 'Account password changed successfully' },
+							400: { description: 'Password does not meet the policy' },
+							401: { description: 'Wrong current password' }
+						}
+					},
+					body: t.Object({
+						currentPassword: t.String({ minLength: 1 }),
+						newPassword: t.String({ minLength: 1 }),
 					}),
 				},
 			)

--- a/tests/unit/modules/users/application/UserAccountPasswordReset.test.ts
+++ b/tests/unit/modules/users/application/UserAccountPasswordReset.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+import { UserAccountPasswordReset } from "../../../../../src/modules/user/application/UserAccountPasswordReset";
+import { User } from "../../../../../src/modules/user/domain/User";
+import { UserRepository } from "../../../../../src/modules/user/domain/UserRepository";
+import { EmailSender } from "../../../../../src/shared/email/domain/EmailSender";
+import { AuthenticationError } from "../../../../../src/shared/errors/AuthenticationError";
+import { InvalidArgumentError } from "../../../../../src/shared/errors/InvalidArgumentError";
+import { NotFoundError } from "../../../../../src/shared/errors/NotFoundError";
+import { Hash } from "../../../../../src/shared/Hash";
+import { JWT } from "../../../../../src/shared/JWT";
+import { Logger } from "../../../../../src/shared/logger/domain/Logger";
+import { Pino } from "../../../../../src/shared/logger/infrastructure/Pino";
+import { UserMother } from "../mothers/UserMother";
+
+describe("UserAccountPasswordReset", () => {
+	let repository: UserRepository;
+	let hash: Hash;
+	let emailSender: EmailSender;
+	let logger: Logger;
+	let jwt: JWT;
+	let reset: UserAccountPasswordReset;
+	let user: User;
+	let token: string;
+
+	beforeEach(() => {
+		repository = {
+			create: async () => undefined,
+			findByEmailOrUsername: async () => null,
+			findByEmail: async () => null,
+			findById: async () => null,
+			update: async () => undefined,
+			updateParticipantId: async () => undefined,
+			findByParticipantId: async () => null,
+		};
+		hash = new Hash();
+		emailSender = { send: async () => undefined };
+		logger = new Pino();
+		jwt = new JWT({ issuer: "issuer", secret: "secret" });
+		reset = new UserAccountPasswordReset(repository, hash, emailSender, logger, jwt);
+
+		user = UserMother.create({ securePassword: null });
+		token = jwt.generate({ id: user.id });
+		spyOn(emailSender, "send").mockResolvedValue();
+	});
+
+	it("resets the account password with a valid token", async () => {
+		spyOn(repository, "findById").mockResolvedValue(user);
+		const updateSpy = spyOn(repository, "update");
+
+		await reset.resetPassword({ token, newPassword: "NewPass2024" });
+
+		expect(updateSpy).toHaveBeenCalledTimes(1);
+		const updatedUser = updateSpy.mock.calls[0][0] as User;
+		expect(await hash.compare("NewPass2024", updatedUser.securePassword as string)).toBe(true);
+	});
+
+	it("throws when no token is provided", async () => {
+		expect(reset.resetPassword({ token: "", newPassword: "NewPass2024" })).rejects.toThrow(AuthenticationError);
+	});
+
+	it("throws when the token is invalid", async () => {
+		expect(reset.resetPassword({ token: "not-a-valid-token", newPassword: "NewPass2024" })).rejects.toThrow(
+			AuthenticationError,
+		);
+	});
+
+	it("rejects a weak new password", async () => {
+		spyOn(repository, "findById").mockResolvedValue(user);
+
+		expect(reset.resetPassword({ token, newPassword: "weak" })).rejects.toThrow(InvalidArgumentError);
+	});
+
+	it("throws when the user does not exist", async () => {
+		spyOn(repository, "findById").mockResolvedValue(null);
+
+		expect(reset.resetPassword({ token, newPassword: "NewPass2024" })).rejects.toThrow(NotFoundError);
+	});
+});

--- a/tests/unit/modules/users/application/UserAccountPasswordUpdater.test.ts
+++ b/tests/unit/modules/users/application/UserAccountPasswordUpdater.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+import { UserAccountPasswordUpdater } from "../../../../../src/modules/user/application/UserAccountPasswordUpdater";
+import { User } from "../../../../../src/modules/user/domain/User";
+import { UserRepository } from "../../../../../src/modules/user/domain/UserRepository";
+import { EmailSender } from "../../../../../src/shared/email/domain/EmailSender";
+import { AuthenticationError } from "../../../../../src/shared/errors/AuthenticationError";
+import { InvalidArgumentError } from "../../../../../src/shared/errors/InvalidArgumentError";
+import { NotFoundError } from "../../../../../src/shared/errors/NotFoundError";
+import { Hash } from "../../../../../src/shared/Hash";
+import { Logger } from "../../../../../src/shared/logger/domain/Logger";
+import { Pino } from "../../../../../src/shared/logger/infrastructure/Pino";
+import { UserMother } from "../mothers/UserMother";
+
+describe("UserAccountPasswordUpdater", () => {
+	let repository: UserRepository;
+	let hash: Hash;
+	let logger: Logger;
+	let emailSender: EmailSender;
+	let updater: UserAccountPasswordUpdater;
+	let migratedUser: User;
+
+	const currentPassword = "CurrentPass1";
+
+	beforeEach(async () => {
+		repository = {
+			create: async () => undefined,
+			findByEmailOrUsername: async () => null,
+			findByEmail: async () => null,
+			findById: async () => null,
+			update: async () => undefined,
+			updateParticipantId: async () => undefined,
+			findByParticipantId: async () => null,
+		};
+		hash = new Hash();
+		logger = new Pino();
+		emailSender = { send: async () => undefined };
+		updater = new UserAccountPasswordUpdater(repository, hash, logger, emailSender);
+
+		migratedUser = UserMother.create({ securePassword: await hash.hash(currentPassword) });
+		spyOn(emailSender, "send").mockResolvedValue();
+	});
+
+	it("changes the account password when the current one is correct", async () => {
+		spyOn(repository, "findById").mockResolvedValue(migratedUser);
+		const updateSpy = spyOn(repository, "update");
+		const emailSpy = spyOn(emailSender, "send");
+
+		await updater.updatePassword({ id: migratedUser.id, currentPassword, newPassword: "NewPass2024" });
+
+		expect(updateSpy).toHaveBeenCalledTimes(1);
+		const updatedUser = updateSpy.mock.calls[0][0] as User;
+		expect(await hash.compare("NewPass2024", updatedUser.securePassword as string)).toBe(true);
+		expect(emailSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects when the current password is wrong", async () => {
+		spyOn(repository, "findById").mockResolvedValue(migratedUser);
+
+		expect(
+			updater.updatePassword({ id: migratedUser.id, currentPassword: "WrongPass9", newPassword: "NewPass2024" }),
+		).rejects.toThrow(AuthenticationError);
+	});
+
+	it("rejects when the user has no account password yet", async () => {
+		const unmigrated = UserMother.create({ securePassword: null });
+		spyOn(repository, "findById").mockResolvedValue(unmigrated);
+
+		expect(
+			updater.updatePassword({ id: unmigrated.id, currentPassword: "whatever1", newPassword: "NewPass2024" }),
+		).rejects.toThrow(AuthenticationError);
+	});
+
+	it("rejects a weak new password", async () => {
+		spyOn(repository, "findById").mockResolvedValue(migratedUser);
+
+		expect(
+			updater.updatePassword({ id: migratedUser.id, currentPassword, newPassword: "weak" }),
+		).rejects.toThrow(InvalidArgumentError);
+	});
+
+	it("throws when the user does not exist", async () => {
+		spyOn(repository, "findById").mockResolvedValue(null);
+
+		expect(
+			updater.updatePassword({ id: "missing-user-id", currentPassword, newPassword: "NewPass2024" }),
+		).rejects.toThrow(NotFoundError);
+	});
+});


### PR DESCRIPTION
## Summary
Adds the change and reset flows for the strong account password, as new endpoints separate from the existing 4-character ones.

- `POST /users/change-account-password` (authenticated): verifies the current account password before setting a new one.
- `POST /users/reset-account-password`: sets a new account password from a valid reset token (reuses the existing forgot-password token).
- Both validate the password policy and send a confirmation email.

## Changes
| File | Change |
|------|--------|
| `src/modules/user/application/UserAccountPasswordUpdater.ts` | Use case: change with current-password verification |
| `src/modules/user/application/UserAccountPasswordReset.ts` | Use case: reset via a valid token |
| `src/server/routes/user-router.ts` | Two new endpoints |

## Test Plan
- [x] `bun test` — all green
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files