### PR TITLE
feat: add ranked game ticket endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ RESEND_FROM_EMAIL=
 SEASON=
 TOURNAMENTS_API_URL=http://localhost:3000
 TOURNAMENTS_WEBHOOK_URL=http://localhost:3001/api/v1/lightning-tournaments/webhook
+# Redis (ranked game ticket store — shared con el game
+  server)
+REDIS_URL=redis://localhost:6379

--- a/.env.test
+++ b/.env.test
@@ -14,3 +14,5 @@ SEASON=5
 PORT=3001
 TOURNAMENTS_API_URL=http://localhost:3000
 TOURNAMENTS_WEBHOOK_URL=http://localhost:3001/api/v1/lightning-tournaments/webhook
+
+REDIS_URL=redis://localhost:6379

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,5 +20,17 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    container_name: evolution-redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 volumes:
   postgres_data:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -24,6 +24,9 @@ export const config = {
 		secret: ensureEnvVariable(process.env.JWT_SECRET as string, "JWT_SECRET"),
 		issuer: ensureEnvVariable(process.env.JWT_ISSUER as string, "JWT_ISSUER"),
 	},
+	redis: {
+		url: ensureEnvVariable(process.env.REDIS_URL as string, "REDIS_URL"),
+	},
 	season: Number(ensureEnvVariable(process.env.SEASON as string, "SEASON")),
 	tournaments: {
 		apiUrl: ensureEnvVariable(process.env.TOURNAMENTS_API_URL as string, "TOURNAMENTS_API_URL"),

--- a/src/modules/ticket/application/IssueGameTicket.ts
+++ b/src/modules/ticket/application/IssueGameTicket.ts
@@ -1,0 +1,14 @@
+import { GameTicket } from "../domain/GameTicket";
+import { RankedTicketRepository } from "../domain/RankedTicketRepository";
+
+export class IssueGameTicket {
+	constructor(private readonly repository: RankedTicketRepository) {}
+
+	async issue({ userId }: { userId: string }): Promise<{ ticket: string }> {
+		const ticket = GameTicket.generate();
+
+		await this.repository.save(ticket, userId);
+
+		return { ticket: ticket.value };
+	}
+}

--- a/src/modules/ticket/domain/GameTicket.ts
+++ b/src/modules/ticket/domain/GameTicket.ts
@@ -1,0 +1,9 @@
+export class GameTicket {
+	static readonly TTL_SECONDS = 30;
+
+	private constructor(public readonly value: string) {}
+
+	static generate(): GameTicket {
+		return new GameTicket(crypto.randomUUID());
+	}
+}

--- a/src/modules/ticket/domain/RankedTicketRepository.ts
+++ b/src/modules/ticket/domain/RankedTicketRepository.ts
@@ -1,0 +1,5 @@
+import { GameTicket } from "./GameTicket";
+
+export interface RankedTicketRepository {
+	save(ticket: GameTicket, userId: string): Promise<void>;
+}

--- a/src/modules/ticket/infrastructure/BunRedisRankedTicketRepository.ts
+++ b/src/modules/ticket/infrastructure/BunRedisRankedTicketRepository.ts
@@ -1,0 +1,18 @@
+import { RedisClient } from "bun";
+
+import { GameTicket } from "../domain/GameTicket";
+import { RankedTicketRepository } from "../domain/RankedTicketRepository";
+
+export class BunRedisRankedTicketRepository implements RankedTicketRepository {
+	private static readonly KEY_PREFIX = "ticket:";
+
+	constructor(private readonly client: RedisClient) {}
+
+	async save(ticket: GameTicket, userId: string): Promise<void> {
+		const key = `${BunRedisRankedTicketRepository.KEY_PREFIX}${ticket.value}`;
+
+		// Atomic SET with TTL in a single command — never set() + expire() (would leave a
+		// window where the key has no TTL and a crash leaks an immortal ticket).
+		await this.client.send("SET", [key, userId, "EX", String(GameTicket.TTL_SECONDS)]);
+	}
+}

--- a/src/server/routes/ticket-router.ts
+++ b/src/server/routes/ticket-router.ts
@@ -1,0 +1,45 @@
+import { bearer } from "@elysiajs/bearer";
+import { RedisClient } from "bun";
+import { Elysia } from "elysia";
+
+import { config } from "../../config";
+import { IssueGameTicket } from "../../modules/ticket/application/IssueGameTicket";
+import { BunRedisRankedTicketRepository } from "../../modules/ticket/infrastructure/BunRedisRankedTicketRepository";
+import { JWT } from "../../shared/JWT";
+import { banGuard } from "../guards/bandGuard";
+
+const jwt = new JWT(config.jwt);
+const redisClient = new RedisClient(config.redis.url);
+const rankedTicketRepository = new BunRedisRankedTicketRepository(redisClient);
+
+export const ticketRouter = new Elysia({ prefix: "/game-tickets" })
+	.use(bearer())
+	.guard(banGuard, (app) =>
+		app.post(
+			"/",
+			async ({ bearer }) => {
+				const { id } = jwt.decode(bearer as string) as { id: string };
+				return new IssueGameTicket(rankedTicketRepository).issue({ userId: id });
+			},
+			{
+				detail: {
+					tags: ["Ranked"],
+					summary: "Issue ranked game ticket",
+					description: "Issues a single-use ticket for the authenticated user to join a ranked game",
+					security: [{ bearerAuth: [] }],
+					responses: {
+						200: {
+							description: "Ticket issued successfully",
+							content: {
+								"application/json": {
+									example: { ticket: "550e8400-e29b-41d4-a716-446655440000" },
+								},
+							},
+						},
+						401: { description: "Invalid or missing token" },
+						403: { description: "User is banned" },
+					},
+				},
+			},
+		),
+	);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,6 +11,7 @@ import { Logger } from "../shared/logger/domain/Logger";
 import { banListRouter } from "./routes/ban-list-router";
 import { leaderboardRouter } from "./routes/leaderboard-router";
 import { statsRouter } from "./routes/stats-router";
+import { ticketRouter } from "./routes/ticket-router";
 import { tournamentRouter } from "./routes/tournament-router";
 import { userRouter } from "./routes/user-router";
 import { wrappedRouter } from "./routes/wrapped-router";
@@ -115,6 +116,7 @@ export class Server {
 				.use(tournamentRouter)
 				.use(statsRouter)
 				.use(wrappedRouter)
+				.use(ticketRouter)
 
 		});
 		this.logger = logger;

--- a/tests/unit/modules/ticket/application/IssueGameTicket.test.ts
+++ b/tests/unit/modules/ticket/application/IssueGameTicket.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+import { IssueGameTicket } from "../../../../../src/modules/ticket/application/IssueGameTicket";
+import { GameTicket } from "../../../../../src/modules/ticket/domain/GameTicket";
+import { RankedTicketRepository } from "../../../../../src/modules/ticket/domain/RankedTicketRepository";
+
+describe("IssueGameTicket", () => {
+	let repository: RankedTicketRepository;
+	let issuer: IssueGameTicket;
+
+	beforeEach(() => {
+		repository = {
+			save: async () => undefined,
+		};
+		issuer = new IssueGameTicket(repository);
+	});
+
+	it("issues a single-use ticket, persists it for the user and returns the ticket value", async () => {
+		const saveSpy = spyOn(repository, "save");
+
+		const result = await issuer.issue({ userId: "user-123" });
+
+		expect(result.ticket).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+		expect(saveSpy).toHaveBeenCalledTimes(1);
+
+		const [savedTicket, savedUserId] = saveSpy.mock.calls[0];
+		expect(savedTicket).toBeInstanceOf(GameTicket);
+		expect((savedTicket as GameTicket).value).toBe(result.ticket);
+		expect(savedUserId).toBe("user-123");
+	});
+
+	it("issues a unique ticket on every call", async () => {
+		const first = await issuer.issue({ userId: "user-123" });
+		const second = await issuer.issue({ userId: "user-123" });
+
+		expect(first.ticket).not.toBe(second.ticket);
+	});
+});


### PR DESCRIPTION
## Summary
Adds an authenticated endpoint that issues a single-use ticket for joining a ranked game.

- `POST /api/v1/game-tickets` (authenticated): returns a single-use ticket for the current user.
- The ticket is a UUID stored in Redis as `ticket:<uuid> -> userId` with a 30s TTL, redeemed once via `GETDEL`.
- Protected by the existing bearer + ban guard, so unauthenticated or banned users can't obtain one.

## Changes
| File | Change |
|------|--------|
| `src/modules/ticket/domain/GameTicket.ts` | Ticket value object (UUID + 30s TTL) |
| `src/modules/ticket/domain/RankedTicketRepository.ts` | Port for persisting tickets |
| `src/modules/ticket/application/IssueGameTicket.ts` | Use case: generate + persist the ticket |
| `src/modules/ticket/infrastructure/BunRedisRankedTicketRepository.ts` | Redis adapter (atomic `SET ... EX`) |
| `src/server/routes/ticket-router.ts` | New `POST /game-tickets` endpoint |
| `src/server/server.ts` | Register the ticket router |
| `src/config/index.ts` | `REDIS_URL` config variable |
| `docker-compose.yaml` | Add a `redis` service |
| `.env.example` / `.env.test` | Document `REDIS_URL` |

## Test Plan
- [x] `bun test` — all green (100 pass)
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
- [x] `docker compose config` validates the new redis service
