### PR TITLE
feat(assets): sign short-lived read URLs for private asset storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,10 @@ TOURNAMENTS_WEBHOOK_URL=http://localhost:3001/api/v1/lightning-tournaments/webho
 # Redis (ranked game ticket store — shared con el game
   server)
 REDIS_URL=redis://localhost:6379
+
+# Cloudflare R2 (private asset bucket — signed read URLs)
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=
+R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+R2_SIGNED_URL_TTL=600

--- a/.env.test
+++ b/.env.test
@@ -16,3 +16,9 @@ TOURNAMENTS_API_URL=http://localhost:3000
 TOURNAMENTS_WEBHOOK_URL=http://localhost:3001/api/v1/lightning-tournaments/webhook
 
 REDIS_URL=redis://localhost:6379
+
+R2_ACCESS_KEY_ID=R2_ACCESS_KEY_ID
+R2_SECRET_ACCESS_KEY=R2_SECRET_ACCESS_KEY
+R2_BUCKET=R2_BUCKET
+R2_ENDPOINT=https://test-account.r2.cloudflarestorage.com
+R2_SIGNED_URL_TTL=600

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,8 @@
 [test]
 
+# load test environment variables before any test runs
+preload = ["./tests/setup.ts"]
+
 # always enable coverage
 coverage = true
 coverageReporter  = ["text"]

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.50",
   "type": "module",
   "scripts": {
-    "test": "bun test --setup=test/setup.ts",
-    "test:coverage": "bun test --setup=test/setup.ts --coverage",
+    "test": "bun test",
+    "test:coverage": "bun test --coverage",
     "dev": "bun run --watch src/index.ts",
     "lint": "eslint --ignore-pattern .gitignore .",
     "lint:fix": "bun run lint -- --fix",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -27,6 +27,13 @@ export const config = {
 	redis: {
 		url: ensureEnvVariable(process.env.REDIS_URL as string, "REDIS_URL"),
 	},
+	r2: {
+		accessKeyId: ensureEnvVariable(process.env.R2_ACCESS_KEY_ID as string, "R2_ACCESS_KEY_ID"),
+		secretAccessKey: ensureEnvVariable(process.env.R2_SECRET_ACCESS_KEY as string, "R2_SECRET_ACCESS_KEY"),
+		bucket: ensureEnvVariable(process.env.R2_BUCKET as string, "R2_BUCKET"),
+		endpoint: ensureEnvVariable(process.env.R2_ENDPOINT as string, "R2_ENDPOINT"),
+		signedUrlTtlSeconds: Number(process.env.R2_SIGNED_URL_TTL ?? "600"),
+	},
 	season: Number(ensureEnvVariable(process.env.SEASON as string, "SEASON")),
 	tournaments: {
 		apiUrl: ensureEnvVariable(process.env.TOURNAMENTS_API_URL as string, "TOURNAMENTS_API_URL"),

--- a/src/modules/assets/domain/AssetUrlSigner.ts
+++ b/src/modules/assets/domain/AssetUrlSigner.ts
@@ -1,0 +1,7 @@
+export interface AssetUrlSigner {
+	/** Signs a short-lived read (GET) URL for a single asset reference. */
+	sign(assetRef: string): string;
+
+	/** Signs many asset references at once, keyed by their reference. */
+	signMany(assetRefs: string[]): Record<string, string>;
+}

--- a/src/modules/assets/infrastructure/R2AssetUrlSigner.ts
+++ b/src/modules/assets/infrastructure/R2AssetUrlSigner.ts
@@ -1,0 +1,25 @@
+import { S3Client } from "bun";
+
+import { AssetUrlSigner } from "../domain/AssetUrlSigner";
+
+/**
+ * Signs read URLs for assets stored in a private R2 (S3-compatible) bucket.
+ *
+ * presign() is synchronous in Bun: it builds a SigV4-signed URL locally, with no
+ * network round-trip. The bucket stays private; clients fetch binaries directly
+ * from R2 using these short-lived URLs, never through this service.
+ */
+export class R2AssetUrlSigner implements AssetUrlSigner {
+	constructor(
+		private readonly client: S3Client,
+		private readonly ttlSeconds: number,
+	) {}
+
+	sign(assetRef: string): string {
+		return this.client.presign(assetRef, { expiresIn: this.ttlSeconds, method: "GET" });
+	}
+
+	signMany(assetRefs: string[]): Record<string, string> {
+		return Object.fromEntries(assetRefs.map((ref) => [ref, this.sign(ref)]));
+	}
+}

--- a/src/modules/assets/infrastructure/createR2AssetUrlSigner.ts
+++ b/src/modules/assets/infrastructure/createR2AssetUrlSigner.ts
@@ -1,0 +1,21 @@
+import { S3Client } from "bun";
+
+import { config } from "../../../config";
+import { AssetUrlSigner } from "../domain/AssetUrlSigner";
+import { R2AssetUrlSigner } from "./R2AssetUrlSigner";
+
+/**
+ * Composition root for the asset URL signer. Builds the Bun S3 client against the
+ * private R2 bucket and wires it into the adapter, so consumers depend only on the
+ * AssetUrlSigner port and never on how the client is constructed.
+ */
+export function createR2AssetUrlSigner(): AssetUrlSigner {
+	const client = new S3Client({
+		accessKeyId: config.r2.accessKeyId,
+		secretAccessKey: config.r2.secretAccessKey,
+		bucket: config.r2.bucket,
+		endpoint: config.r2.endpoint,
+	});
+
+	return new R2AssetUrlSigner(client, config.r2.signedUrlTtlSeconds);
+}

--- a/tests/unit/modules/assets/infrastructure/R2AssetUrlSigner.test.ts
+++ b/tests/unit/modules/assets/infrastructure/R2AssetUrlSigner.test.ts
@@ -1,0 +1,42 @@
+import { S3Client } from "bun";
+import { describe, expect, it } from "bun:test";
+
+import { R2AssetUrlSigner } from "../../../../../src/modules/assets/infrastructure/R2AssetUrlSigner";
+
+describe("R2AssetUrlSigner", () => {
+	// presign() signs locally with SigV4 — no network call — so fake credentials
+	// are enough to assert the shape of the URL the client would receive.
+	const client = new S3Client({
+		accessKeyId: "test-access-key-id",
+		secretAccessKey: "test-secret-access-key",
+		bucket: "test-bucket",
+		endpoint: "https://test-account.r2.cloudflarestorage.com",
+	});
+	const ttlSeconds = 600;
+
+	it("signs a short-lived read URL for an asset reference", () => {
+		const signer = new R2AssetUrlSigner(client, ttlSeconds);
+
+		const url = signer.sign("sleeves/dragon.png");
+
+		expect(url).toMatch(/^https:\/\//);
+		expect(url).toContain("dragon.png");
+		expect(url).toContain("X-Amz-Expires=600");
+		expect(url).toContain("X-Amz-Signature=");
+	});
+
+	it("signs many references and keys each URL by its reference", () => {
+		const signer = new R2AssetUrlSigner(client, ttlSeconds);
+		const refs = ["sleeves/dragon.png", "playmats/arena.png"];
+
+		const urls = signer.signMany(refs);
+
+		expect(Object.keys(urls)).toEqual(refs);
+		for (const ref of refs) {
+			const fileName = ref.split("/")[1];
+			expect(urls[ref]).toMatch(/^https:\/\//);
+			expect(urls[ref]).toContain(fileName);
+			expect(urls[ref]).toContain("X-Amz-Expires=600");
+		}
+	});
+});


### PR DESCRIPTION
## Summary
Adds the ability to sign short-lived read URLs for assets stored in a private, S3-compatible (Cloudflare R2) bucket, so clients can fetch binaries directly from storage without exposing credentials or routing large files through the API.

- New `assets` module (hexagonal): an `AssetUrlSigner` port with an `R2AssetUrlSigner` adapter backed by Bun's native `S3Client`, presigning GET URLs that expire quickly (default 600s).
- A `createR2AssetUrlSigner` composition helper wires the signer from configuration, so consumers depend only on the port — not on how the client is built.
- Also fixes the test harness so the suite actually loads `.env.test`: it was wired through an unsupported flag pointing at a path that does not exist, so it silently fell back to the real `.env`.

This only signs read URLs — uploading binaries and the HTTP endpoints that expose them are out of scope.

## Changes
| File | Change |
|------|--------|
| `src/modules/assets/domain/AssetUrlSigner.ts` | Port: `sign()` / `signMany()` |
| `src/modules/assets/infrastructure/R2AssetUrlSigner.ts` | Bun S3 adapter — synchronous SigV4 presign (GET) |
| `src/modules/assets/infrastructure/createR2AssetUrlSigner.ts` | Composition root building the signer from config |
| `src/config/index.ts` | `r2` config (credentials, bucket, endpoint, signed-URL TTL) |
| `.env.example` / `.env.test` | Document/declare the R2 variables |
| `bunfig.toml` | Preload `tests/setup.ts` so tests load `.env.test` |
| `package.json` | Drop the dead `--setup` flag from the test scripts |
| `tests/unit/modules/assets/infrastructure/R2AssetUrlSigner.test.ts` | Tests for the signer (100% coverage) |

## Test Plan
- [x] `bun test` — all green (104 pass)
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
