### PR TITLE
feat(cosmetics): add isolated data model, DataSource and migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "test": "bun test",
     "test:coverage": "bun test --coverage",
     "dev": "bun run --watch src/index.ts",
+    "migration:cosmetics:run": "bun run src/scripts/run-cosmetics-migrations.ts",
+    "migration:cosmetics:revert": "bun run src/scripts/run-cosmetics-migrations.ts --revert",
     "lint": "eslint --ignore-pattern .gitignore .",
     "lint:fix": "bun run lint -- --fix",
     "prepare": "if [ \"$NODE_ENV\" != \"production\" ]; then husky install; fi",

--- a/src/cosmetics-data-source.ts
+++ b/src/cosmetics-data-source.ts
@@ -1,0 +1,30 @@
+import { join } from "path";
+import { DataSource, DataSourceOptions } from "typeorm";
+
+import { config } from "./evolution-types/src/config";
+import { CosmeticEntity } from "./modules/catalog/infrastructure/CosmeticEntity";
+import { EntitlementEntity } from "./modules/entitlements/infrastructure/EntitlementEntity";
+import { UserLoadoutEntity } from "./modules/loadout/infrastructure/UserLoadoutEntity";
+
+// Cosmetics owns its own DataSource and migration history, isolated from the shared
+// schema in evolution-types. It points at the same Postgres but tracks migrations in
+// its own table (`cosmetics_migrations`), so the shared `migrations` table — run by
+// the game server — never sees these changes. It only knows about cosmetics tables;
+// the foreign key to users(id) is declared in raw SQL inside the migration, so this
+// DataSource never touches the shared `users` table.
+const options: DataSourceOptions = {
+	type: "postgres",
+	host: config.postgres.host,
+	port: config.postgres.port,
+	username: config.postgres.username,
+	password: config.postgres.password,
+	database: config.postgres.database,
+	synchronize: false,
+	logging: true,
+	entities: [CosmeticEntity, UserLoadoutEntity, EntitlementEntity],
+	subscribers: [],
+	migrations: [join(__dirname, "/migrations/*.ts")],
+	migrationsTableName: "cosmetics_migrations",
+};
+
+export const cosmeticsDataSource = new DataSource(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { cosmeticsDataSource } from "./cosmetics-data-source";
 import { PostgresTypeORM } from "./evolution-types/src/PostgresTypeORM";
 import { Server } from "./server/server";
 import { Pino } from "./shared/logger/infrastructure/Pino";
@@ -7,6 +8,7 @@ const logger = new Pino();
 void (async () => {
 	const database = new PostgresTypeORM();
 	await database.connect().catch((error) => logger.error(error));
+	await cosmeticsDataSource.initialize().catch((error) => logger.error(error));
 	const server = new Server(logger);
 	server.start();
 })();

--- a/src/migrations/1780873543822-create_cosmetics_tables.ts
+++ b/src/migrations/1780873543822-create_cosmetics_tables.ts
@@ -1,0 +1,67 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateCosmeticsTables1780873543822 implements MigrationInterface {
+	name = "CreateCosmeticsTables1780873543822";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+
+		await queryRunner.query(
+			`CREATE TYPE "cosmetic_type_enum" AS ENUM('SLEEVE', 'PLAYMAT', 'CARD_BACK', 'AVATAR', 'SUMMON_EFFECT', 'MUSIC', 'TITLE')`
+		);
+		await queryRunner.query(
+			`CREATE TYPE "cosmetic_tier_enum" AS ENUM('STANDARD', 'REGISTERED', 'DONOR')`
+		);
+		await queryRunner.query(`CREATE TYPE "grant_type_enum" AS ENUM('TIER', 'COSMETIC')`);
+		await queryRunner.query(
+			`CREATE TYPE "entitlement_source_enum" AS ENUM('REGISTRATION', 'DONATION', 'PURCHASE', 'CAMPAIGN')`
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE "cosmetics" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "type" "cosmetic_type_enum" NOT NULL, "tier" "cosmetic_tier_enum" NOT NULL, "asset_ref" character varying NOT NULL, "display_name" character varying NOT NULL, "active" boolean NOT NULL DEFAULT true, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_cosmetics_id" PRIMARY KEY ("id"))`
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE "user_loadouts" ("user_id" character varying NOT NULL, "cosmetic_type" "cosmetic_type_enum" NOT NULL, "cosmetic_id" uuid NOT NULL, "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_user_loadouts" PRIMARY KEY ("user_id", "cosmetic_type"))`
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE "entitlements" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "user_id" character varying NOT NULL, "grant_type" "grant_type_enum" NOT NULL, "grant_value" character varying NOT NULL, "source" "entitlement_source_enum" NOT NULL, "expires_at" TIMESTAMP WITH TIME ZONE, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_entitlements_id" PRIMARY KEY ("id"))`
+		);
+
+		await queryRunner.query(
+			`CREATE INDEX "IDX_entitlements_user_id" ON "entitlements" ("user_id")`
+		);
+
+		// Foreign keys to the shared users table (users.id is varchar). Declared in raw
+		// SQL so the cosmetics DataSource never needs to map the shared UserProfileEntity.
+		await queryRunner.query(
+			`ALTER TABLE "user_loadouts" ADD CONSTRAINT "FK_user_loadouts_user" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "user_loadouts" ADD CONSTRAINT "FK_user_loadouts_cosmetic" FOREIGN KEY ("cosmetic_id") REFERENCES "cosmetics"("id") ON DELETE RESTRICT ON UPDATE NO ACTION`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "entitlements" ADD CONSTRAINT "FK_entitlements_user" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "entitlements" DROP CONSTRAINT "FK_entitlements_user"`);
+		await queryRunner.query(
+			`ALTER TABLE "user_loadouts" DROP CONSTRAINT "FK_user_loadouts_cosmetic"`
+		);
+		await queryRunner.query(`ALTER TABLE "user_loadouts" DROP CONSTRAINT "FK_user_loadouts_user"`);
+
+		await queryRunner.query(`DROP INDEX "IDX_entitlements_user_id"`);
+
+		await queryRunner.query(`DROP TABLE "entitlements"`);
+		await queryRunner.query(`DROP TABLE "user_loadouts"`);
+		await queryRunner.query(`DROP TABLE "cosmetics"`);
+
+		await queryRunner.query(`DROP TYPE "entitlement_source_enum"`);
+		await queryRunner.query(`DROP TYPE "grant_type_enum"`);
+		await queryRunner.query(`DROP TYPE "cosmetic_tier_enum"`);
+		await queryRunner.query(`DROP TYPE "cosmetic_type_enum"`);
+	}
+}

--- a/src/modules/catalog/domain/CosmeticTier.ts
+++ b/src/modules/catalog/domain/CosmeticTier.ts
@@ -1,0 +1,5 @@
+export enum CosmeticTier {
+	STANDARD = "STANDARD",
+	REGISTERED = "REGISTERED",
+	DONOR = "DONOR",
+}

--- a/src/modules/catalog/domain/CosmeticType.ts
+++ b/src/modules/catalog/domain/CosmeticType.ts
@@ -1,0 +1,9 @@
+export enum CosmeticType {
+	SLEEVE = "SLEEVE",
+	PLAYMAT = "PLAYMAT",
+	CARD_BACK = "CARD_BACK",
+	AVATAR = "AVATAR",
+	SUMMON_EFFECT = "SUMMON_EFFECT",
+	MUSIC = "MUSIC",
+	TITLE = "TITLE",
+}

--- a/src/modules/catalog/infrastructure/CosmeticEntity.ts
+++ b/src/modules/catalog/infrastructure/CosmeticEntity.ts
@@ -1,0 +1,37 @@
+import {
+	Column,
+	CreateDateColumn,
+	Entity,
+	PrimaryGeneratedColumn,
+	UpdateDateColumn,
+} from "typeorm";
+
+import { CosmeticTier } from "../domain/CosmeticTier";
+import { CosmeticType } from "../domain/CosmeticType";
+
+@Entity({ name: "cosmetics" })
+export class CosmeticEntity {
+	@PrimaryGeneratedColumn("uuid")
+	id: string;
+
+	@Column({ type: "enum", enum: CosmeticType, enumName: "cosmetic_type_enum" })
+	type: CosmeticType;
+
+	@Column({ type: "enum", enum: CosmeticTier, enumName: "cosmetic_tier_enum" })
+	tier: CosmeticTier;
+
+	@Column({ name: "asset_ref" })
+	assetRef: string;
+
+	@Column({ name: "display_name" })
+	displayName: string;
+
+	@Column({ default: true })
+	active: boolean;
+
+	@CreateDateColumn({ name: "created_at" })
+	createdAt: Date;
+
+	@UpdateDateColumn({ name: "updated_at" })
+	updatedAt: Date;
+}

--- a/src/modules/entitlements/domain/EntitlementSource.ts
+++ b/src/modules/entitlements/domain/EntitlementSource.ts
@@ -1,0 +1,6 @@
+export enum EntitlementSource {
+	REGISTRATION = "REGISTRATION",
+	DONATION = "DONATION",
+	PURCHASE = "PURCHASE",
+	CAMPAIGN = "CAMPAIGN",
+}

--- a/src/modules/entitlements/domain/GrantType.ts
+++ b/src/modules/entitlements/domain/GrantType.ts
@@ -1,0 +1,4 @@
+export enum GrantType {
+	TIER = "TIER",
+	COSMETIC = "COSMETIC",
+}

--- a/src/modules/entitlements/infrastructure/EntitlementEntity.ts
+++ b/src/modules/entitlements/infrastructure/EntitlementEntity.ts
@@ -1,0 +1,30 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from "typeorm";
+
+import { EntitlementSource } from "../domain/EntitlementSource";
+import { GrantType } from "../domain/GrantType";
+
+@Entity({ name: "entitlements" })
+export class EntitlementEntity {
+	@PrimaryGeneratedColumn("uuid")
+	id: string;
+
+	// FK to users(id), which is varchar in the shared schema — not uuid.
+	@Index()
+	@Column({ name: "user_id", type: "varchar" })
+	userId: string;
+
+	@Column({ name: "grant_type", type: "enum", enum: GrantType, enumName: "grant_type_enum" })
+	grantType: GrantType;
+
+	@Column({ name: "grant_value" })
+	grantValue: string;
+
+	@Column({ type: "enum", enum: EntitlementSource, enumName: "entitlement_source_enum" })
+	source: EntitlementSource;
+
+	@Column({ name: "expires_at", type: "timestamptz", nullable: true })
+	expiresAt: Date | null;
+
+	@CreateDateColumn({ name: "created_at" })
+	createdAt: Date;
+}

--- a/src/modules/loadout/infrastructure/UserLoadoutEntity.ts
+++ b/src/modules/loadout/infrastructure/UserLoadoutEntity.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from "typeorm";
+
+import { CosmeticType } from "../../catalog/domain/CosmeticType";
+
+// One row per equipped slot (user_id, cosmetic_type). The cosmetic_type is part of
+// the primary key so a user has at most one cosmetic equipped per slot.
+@Entity({ name: "user_loadouts" })
+export class UserLoadoutEntity {
+	// FK to users(id), which is varchar in the shared schema — not uuid.
+	@PrimaryColumn({ name: "user_id", type: "varchar" })
+	userId: string;
+
+	@PrimaryColumn({
+		name: "cosmetic_type",
+		type: "enum",
+		enum: CosmeticType,
+		enumName: "cosmetic_type_enum",
+	})
+	cosmeticType: CosmeticType;
+
+	@Column({ name: "cosmetic_id", type: "uuid" })
+	cosmeticId: string;
+
+	@UpdateDateColumn({ name: "updated_at" })
+	updatedAt: Date;
+}

--- a/src/scripts/run-cosmetics-migrations.ts
+++ b/src/scripts/run-cosmetics-migrations.ts
@@ -1,0 +1,28 @@
+import { cosmeticsDataSource } from "../cosmetics-data-source";
+
+// Manual migration runner for the cosmetics schema — run on deploy when cosmetics
+// migrations change. Programmatic on purpose: the API runs on Bun, while the shared
+// submodule uses the TypeORM CLI via ts-node. Migrations are written by hand, so
+// `migration:generate` is not needed — only run / revert.
+async function main(): Promise<void> {
+	const shouldRevert = process.argv.includes("--revert");
+
+	await cosmeticsDataSource.initialize();
+
+	try {
+		if (shouldRevert) {
+			await cosmeticsDataSource.undoLastMigration();
+		} else {
+			await cosmeticsDataSource.runMigrations();
+		}
+	} finally {
+		await cosmeticsDataSource.destroy();
+	}
+}
+
+main()
+	.then(() => process.exit(0))
+	.catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});


### PR DESCRIPTION
## Summary
Adds the persistence foundation for cosmetics (catalog, loadouts and entitlements), fully isolated from the shared database schema so the game server is never affected by cosmetics changes.

- Three TypeORM entities (`cosmetics`, `user_loadouts`, `entitlements`) plus their domain enums, owned by the API.
- A dedicated `DataSource` that points at the same Postgres but tracks its **own** migrations in a separate table (`cosmetics_migrations`), leaving the shared migration history untouched. It maps only cosmetics tables — the foreign key to `users(id)` is declared in raw SQL, so it never touches the shared `users` table.
- An initial hand-written migration creating the tables, enums and foreign keys. User references are `varchar` to match the existing `users.id` type.
- A small programmatic migration runner (run / revert) for Bun, executed manually on deploy.

## Changes
| File | Change |
|------|--------|
| `src/modules/catalog/domain/CosmeticType.ts`, `CosmeticTier.ts` | Catalog enums |
| `src/modules/catalog/infrastructure/CosmeticEntity.ts` | `cosmetics` entity |
| `src/modules/loadout/infrastructure/UserLoadoutEntity.ts` | `user_loadouts` entity (composite PK) |
| `src/modules/entitlements/domain/GrantType.ts`, `EntitlementSource.ts` | Entitlement enums |
| `src/modules/entitlements/infrastructure/EntitlementEntity.ts` | `entitlements` entity |
| `src/cosmetics-data-source.ts` | Dedicated DataSource (own `migrationsTableName`) |
| `src/migrations/1780873543822-create_cosmetics_tables.ts` | Initial migration (tables, enums, FKs) |
| `src/scripts/run-cosmetics-migrations.ts` | Programmatic run/revert runner |
| `package.json` | `migration:cosmetics:run` / `:revert` scripts |
| `src/index.ts` | Initialize the cosmetics DataSource at startup |

## Test Plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
- [x] `bun test` — all green
- [x] Migration verified against a real Postgres 16 (ephemeral container): `up` creates the tables, enums, index and foreign keys (including `user_id varchar → users(id)`) and records itself in `cosmetics_migrations`; `down` cleanly drops everything back.
