### PR TITLE
feat(catalog): add cosmetics catalog module and standard set seed

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "bun run --watch src/index.ts",
     "migration:cosmetics:run": "bun run src/scripts/run-cosmetics-migrations.ts",
     "migration:cosmetics:revert": "bun run src/scripts/run-cosmetics-migrations.ts --revert",
+    "seed:cosmetics": "bun run src/scripts/seed-cosmetics.ts",
     "lint": "eslint --ignore-pattern .gitignore .",
     "lint:fix": "bun run lint -- --fix",
     "prepare": "if [ \"$NODE_ENV\" != \"production\" ]; then husky install; fi",

--- a/src/modules/catalog/application/SeedStandardCosmetics.ts
+++ b/src/modules/catalog/application/SeedStandardCosmetics.ts
@@ -1,0 +1,38 @@
+import { Cosmetic } from "../domain/Cosmetic";
+import { CosmeticRepository } from "../domain/CosmeticRepository";
+import { STANDARD_COSMETICS } from "./standardCosmetics";
+
+// Idempotent seed of the standard cosmetic set. Existing cosmetics are matched by
+// their asset_ref (one prefix == one cosmetic), so re-running only inserts what is
+// missing.
+export class SeedStandardCosmetics {
+	constructor(private readonly repository: CosmeticRepository) {}
+
+	async run(): Promise<{ created: number; skipped: number }> {
+		const existing = await this.repository.findAll();
+		const existingRefs = new Set(existing.map((cosmetic) => cosmetic.assetRef));
+
+		let created = 0;
+		let skipped = 0;
+
+		for (const item of STANDARD_COSMETICS) {
+			if (existingRefs.has(item.assetRef)) {
+				skipped++;
+				continue;
+			}
+
+			await this.repository.save(
+				Cosmetic.create({
+					id: crypto.randomUUID(),
+					type: item.type,
+					tier: item.tier,
+					assetRef: item.assetRef,
+					displayName: item.displayName,
+				}),
+			);
+			created++;
+		}
+
+		return { created, skipped };
+	}
+}

--- a/src/modules/catalog/application/standardCosmetics.ts
+++ b/src/modules/catalog/application/standardCosmetics.ts
@@ -1,0 +1,23 @@
+import { CosmeticTier } from "../domain/CosmeticTier";
+import { CosmeticType } from "../domain/CosmeticType";
+
+export interface StandardCosmeticSeed {
+	type: CosmeticType;
+	tier: CosmeticTier;
+	assetRef: string;
+	displayName: string;
+}
+
+// The standard set every player gets. asset_ref is the R2 folder prefix; the
+// individual files (render/preview for sleeves, gltf/bin/texture for playmats)
+// live under it and are resolved at serve time.
+export const STANDARD_COSMETICS: StandardCosmeticSeed[] = [
+	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.STANDARD, assetRef: "sleeves/baby-frog/", displayName: "Baby Frog" },
+	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.STANDARD, assetRef: "sleeves/classic/", displayName: "Classic" },
+	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.STANDARD, assetRef: "sleeves/kagura/", displayName: "Kagura" },
+	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.STANDARD, assetRef: "sleeves/mystical-witch/", displayName: "Mystical Witch" },
+	{ type: CosmeticType.PLAYMAT, tier: CosmeticTier.STANDARD, assetRef: "playmats/pallet-covered-a/", displayName: "Pallet Covered A" },
+	{ type: CosmeticType.PLAYMAT, tier: CosmeticTier.STANDARD, assetRef: "playmats/pallet-covered-b/", displayName: "Pallet Covered B" },
+	{ type: CosmeticType.PLAYMAT, tier: CosmeticTier.STANDARD, assetRef: "playmats/pallet-wood/", displayName: "Pallet Wood" },
+	{ type: CosmeticType.PLAYMAT, tier: CosmeticTier.STANDARD, assetRef: "playmats/plaque/", displayName: "Plaque" },
+];

--- a/src/modules/catalog/domain/Cosmetic.ts
+++ b/src/modules/catalog/domain/Cosmetic.ts
@@ -1,0 +1,71 @@
+import { InvalidArgumentError } from "../../../shared/errors/InvalidArgumentError";
+import { CosmeticTier } from "./CosmeticTier";
+import { CosmeticType } from "./CosmeticType";
+
+export class Cosmetic {
+	private constructor(
+		public readonly id: string,
+		public readonly type: CosmeticType,
+		public readonly tier: CosmeticTier,
+		public readonly assetRef: string,
+		public readonly displayName: string,
+		public readonly active: boolean,
+	) {}
+
+	static create({
+		id,
+		type,
+		tier,
+		assetRef,
+		displayName,
+	}: {
+		id: string;
+		type: CosmeticType;
+		tier: CosmeticTier;
+		assetRef: string;
+		displayName: string;
+	}): Cosmetic {
+		if (!assetRef.trim()) {
+			throw new InvalidArgumentError("assetRef cannot be empty");
+		}
+		// assetRef is a folder prefix in object storage — its files (render/preview,
+		// gltf/bin/texture) live under it, so it must end with "/".
+		if (!assetRef.endsWith("/")) {
+			throw new InvalidArgumentError("assetRef must be a folder prefix ending with '/'");
+		}
+		if (!displayName.trim()) {
+			throw new InvalidArgumentError("displayName cannot be empty");
+		}
+
+		return new Cosmetic(id, type, tier, assetRef, displayName, true);
+	}
+
+	static from(data: {
+		id: string;
+		type: CosmeticType;
+		tier: CosmeticTier;
+		assetRef: string;
+		displayName: string;
+		active: boolean;
+	}): Cosmetic {
+		return new Cosmetic(data.id, data.type, data.tier, data.assetRef, data.displayName, data.active);
+	}
+
+	toPrimitives(): {
+		id: string;
+		type: CosmeticType;
+		tier: CosmeticTier;
+		assetRef: string;
+		displayName: string;
+		active: boolean;
+	} {
+		return {
+			id: this.id,
+			type: this.type,
+			tier: this.tier,
+			assetRef: this.assetRef,
+			displayName: this.displayName,
+			active: this.active,
+		};
+	}
+}

--- a/src/modules/catalog/domain/CosmeticRepository.ts
+++ b/src/modules/catalog/domain/CosmeticRepository.ts
@@ -1,0 +1,6 @@
+import { Cosmetic } from "./Cosmetic";
+
+export interface CosmeticRepository {
+	findAll(): Promise<Cosmetic[]>;
+	save(cosmetic: Cosmetic): Promise<void>;
+}

--- a/src/modules/catalog/infrastructure/CosmeticPostgresRepository.ts
+++ b/src/modules/catalog/infrastructure/CosmeticPostgresRepository.ts
@@ -1,0 +1,38 @@
+import { cosmeticsDataSource } from "../../../cosmetics-data-source";
+import { Cosmetic } from "../domain/Cosmetic";
+import { CosmeticRepository } from "../domain/CosmeticRepository";
+import { CosmeticEntity } from "./CosmeticEntity";
+
+export class CosmeticPostgresRepository implements CosmeticRepository {
+	async findAll(): Promise<Cosmetic[]> {
+		const repository = cosmeticsDataSource.getRepository(CosmeticEntity);
+		const entities = await repository.find();
+
+		return entities.map((entity) =>
+			Cosmetic.from({
+				id: entity.id,
+				type: entity.type,
+				tier: entity.tier,
+				assetRef: entity.assetRef,
+				displayName: entity.displayName,
+				active: entity.active,
+			}),
+		);
+	}
+
+	async save(cosmetic: Cosmetic): Promise<void> {
+		const repository = cosmeticsDataSource.getRepository(CosmeticEntity);
+		const data = cosmetic.toPrimitives();
+
+		const entity = repository.create({
+			id: data.id,
+			type: data.type,
+			tier: data.tier,
+			assetRef: data.assetRef,
+			displayName: data.displayName,
+			active: data.active,
+		});
+
+		await repository.save(entity);
+	}
+}

--- a/src/scripts/seed-cosmetics.ts
+++ b/src/scripts/seed-cosmetics.ts
@@ -1,0 +1,22 @@
+import { cosmeticsDataSource } from "../cosmetics-data-source";
+import { SeedStandardCosmetics } from "../modules/catalog/application/SeedStandardCosmetics";
+import { CosmeticPostgresRepository } from "../modules/catalog/infrastructure/CosmeticPostgresRepository";
+
+// Seeds the standard cosmetic set. Idempotent — safe to run on every deploy.
+async function main(): Promise<void> {
+	await cosmeticsDataSource.initialize();
+
+	try {
+		const result = await new SeedStandardCosmetics(new CosmeticPostgresRepository()).run();
+		console.log(`Cosmetics seed complete: ${result.created} created, ${result.skipped} skipped`);
+	} finally {
+		await cosmeticsDataSource.destroy();
+	}
+}
+
+main()
+	.then(() => process.exit(0))
+	.catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});

--- a/tests/unit/modules/catalog/application/SeedStandardCosmetics.test.ts
+++ b/tests/unit/modules/catalog/application/SeedStandardCosmetics.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+
+import { SeedStandardCosmetics } from "../../../../../src/modules/catalog/application/SeedStandardCosmetics";
+import { STANDARD_COSMETICS } from "../../../../../src/modules/catalog/application/standardCosmetics";
+import { Cosmetic } from "../../../../../src/modules/catalog/domain/Cosmetic";
+import { CosmeticRepository } from "../../../../../src/modules/catalog/domain/CosmeticRepository";
+
+function fakeRepository(existing: Cosmetic[]): { repository: CosmeticRepository; saved: Cosmetic[] } {
+	const saved: Cosmetic[] = [];
+	const repository: CosmeticRepository = {
+		findAll: async () => existing,
+		save: async (cosmetic) => {
+			saved.push(cosmetic);
+		},
+	};
+
+	return { repository, saved };
+}
+
+describe("SeedStandardCosmetics", () => {
+	it("seeds every standard cosmetic when the catalog is empty", async () => {
+		const { repository, saved } = fakeRepository([]);
+
+		const result = await new SeedStandardCosmetics(repository).run();
+
+		expect(result.created).toBe(STANDARD_COSMETICS.length);
+		expect(result.skipped).toBe(0);
+		expect(saved).toHaveLength(STANDARD_COSMETICS.length);
+		// asset_ref is a folder prefix (multi-file assets live under it)
+		for (const cosmetic of saved) {
+			expect(cosmetic.assetRef.endsWith("/")).toBe(true);
+		}
+	});
+
+	it("is idempotent: skips cosmetics already present by asset_ref", async () => {
+		const [first] = STANDARD_COSMETICS;
+		const existing = [
+			Cosmetic.create({
+				id: "already-there",
+				type: first.type,
+				tier: first.tier,
+				assetRef: first.assetRef,
+				displayName: first.displayName,
+			}),
+		];
+		const { repository, saved } = fakeRepository(existing);
+
+		const result = await new SeedStandardCosmetics(repository).run();
+
+		expect(result.created).toBe(STANDARD_COSMETICS.length - 1);
+		expect(result.skipped).toBe(1);
+		expect(saved).toHaveLength(STANDARD_COSMETICS.length - 1);
+		expect(saved.some((c) => c.assetRef === first.assetRef)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
Adds the catalog bounded context for cosmetics and seeds the standard set every player gets.

- `Cosmetic` domain model and `CosmeticRepository` port, with a Postgres adapter over the dedicated cosmetics DataSource.
- An **idempotent** `SeedStandardCosmetics` use case plus a manual seed script (`bun run seed:cosmetics`). Existing cosmetics are matched by `asset_ref`, so re-running only inserts what is missing.
- `asset_ref` is stored as a **folder prefix**, not a single file: cosmetic assets are multi-file (render + preview for sleeves; model + geometry + texture for playmats), so the files under a prefix are resolved together when served.

## Changes
| File | Change |
|------|--------|
| `src/modules/catalog/domain/Cosmetic.ts` | Domain model (prefix invariant on `asset_ref`) |
| `src/modules/catalog/domain/CosmeticRepository.ts` | Repository port (`findAll`, `save`) |
| `src/modules/catalog/infrastructure/CosmeticPostgresRepository.ts` | Postgres adapter |
| `src/modules/catalog/application/standardCosmetics.ts` | Standard set definition (8 cosmetics) |
| `src/modules/catalog/application/SeedStandardCosmetics.ts` | Idempotent seed use case |
| `src/scripts/seed-cosmetics.ts` | Manual seed runner |
| `package.json` | `seed:cosmetics` script |
| `tests/unit/modules/catalog/application/SeedStandardCosmetics.test.ts` | Use-case tests |

## Test Plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
- [x] `bun test` — all green
- [x] Verified against a real Postgres 16 (ephemeral container): ran the migration, then the seed inserted all 8 cosmetics (`8 created, 0 skipped`); a second run was idempotent (`0 created, 8 skipped`) with the expected rows and prefix `asset_ref`s.
