### PR TITLE
feat(loadout, entitlements): add loadout and entitlements domain modules

### DIFF
--- a/src/modules/entitlements/domain/Entitlement.ts
+++ b/src/modules/entitlements/domain/Entitlement.ts
@@ -1,0 +1,79 @@
+import { InvalidArgumentError } from "../../../shared/errors/InvalidArgumentError";
+import { EntitlementSource } from "./EntitlementSource";
+import { GrantType } from "./GrantType";
+
+// A granted access right (a tier or a specific cosmetic). `source` records where it
+// came from (registration, donation, purchase, campaign) so it can be revoked or
+// reasoned about independently. `canUse()` lives in the entitlements policy (A6).
+export class Entitlement {
+	private constructor(
+		public readonly id: string,
+		public readonly userId: string,
+		public readonly grantType: GrantType,
+		public readonly grantValue: string,
+		public readonly source: EntitlementSource,
+		public readonly expiresAt: Date | null,
+	) {}
+
+	static create({
+		id,
+		userId,
+		grantType,
+		grantValue,
+		source,
+		expiresAt,
+	}: {
+		id: string;
+		userId: string;
+		grantType: GrantType;
+		grantValue: string;
+		source: EntitlementSource;
+		expiresAt: Date | null;
+	}): Entitlement {
+		if (!grantValue.trim()) {
+			throw new InvalidArgumentError("grantValue cannot be empty");
+		}
+
+		return new Entitlement(id, userId, grantType, grantValue, source, expiresAt);
+	}
+
+	static from(data: {
+		id: string;
+		userId: string;
+		grantType: GrantType;
+		grantValue: string;
+		source: EntitlementSource;
+		expiresAt: Date | null;
+	}): Entitlement {
+		return new Entitlement(
+			data.id,
+			data.userId,
+			data.grantType,
+			data.grantValue,
+			data.source,
+			data.expiresAt,
+		);
+	}
+
+	isActiveAt(date: Date): boolean {
+		return this.expiresAt === null || this.expiresAt.getTime() > date.getTime();
+	}
+
+	toPrimitives(): {
+		id: string;
+		userId: string;
+		grantType: GrantType;
+		grantValue: string;
+		source: EntitlementSource;
+		expiresAt: Date | null;
+	} {
+		return {
+			id: this.id,
+			userId: this.userId,
+			grantType: this.grantType,
+			grantValue: this.grantValue,
+			source: this.source,
+			expiresAt: this.expiresAt,
+		};
+	}
+}

--- a/src/modules/entitlements/domain/EntitlementRepository.ts
+++ b/src/modules/entitlements/domain/EntitlementRepository.ts
@@ -1,0 +1,6 @@
+import { Entitlement } from "./Entitlement";
+
+export interface EntitlementRepository {
+	findByUserId(userId: string): Promise<Entitlement[]>;
+	save(entitlement: Entitlement): Promise<void>;
+}

--- a/src/modules/entitlements/infrastructure/EntitlementPostgresRepository.ts
+++ b/src/modules/entitlements/infrastructure/EntitlementPostgresRepository.ts
@@ -1,0 +1,38 @@
+import { cosmeticsDataSource } from "../../../cosmetics-data-source";
+import { Entitlement } from "../domain/Entitlement";
+import { EntitlementRepository } from "../domain/EntitlementRepository";
+import { EntitlementEntity } from "./EntitlementEntity";
+
+export class EntitlementPostgresRepository implements EntitlementRepository {
+	async findByUserId(userId: string): Promise<Entitlement[]> {
+		const repository = cosmeticsDataSource.getRepository(EntitlementEntity);
+		const rows = await repository.find({ where: { userId } });
+
+		return rows.map((row) =>
+			Entitlement.from({
+				id: row.id,
+				userId: row.userId,
+				grantType: row.grantType,
+				grantValue: row.grantValue,
+				source: row.source,
+				expiresAt: row.expiresAt,
+			}),
+		);
+	}
+
+	async save(entitlement: Entitlement): Promise<void> {
+		const repository = cosmeticsDataSource.getRepository(EntitlementEntity);
+		const data = entitlement.toPrimitives();
+
+		const entity = repository.create({
+			id: data.id,
+			userId: data.userId,
+			grantType: data.grantType,
+			grantValue: data.grantValue,
+			source: data.source,
+			expiresAt: data.expiresAt,
+		});
+
+		await repository.save(entity);
+	}
+}

--- a/src/modules/loadout/domain/Loadout.ts
+++ b/src/modules/loadout/domain/Loadout.ts
@@ -1,0 +1,34 @@
+import { CosmeticType } from "../../catalog/domain/CosmeticType";
+
+export interface LoadoutItem {
+	cosmeticType: CosmeticType;
+	cosmeticId: string;
+}
+
+// A user's active loadout: at most one cosmetic equipped per slot (cosmetic type).
+export class Loadout {
+	private constructor(
+		public readonly userId: string,
+		private readonly equipped: Map<CosmeticType, string>,
+	) {}
+
+	static empty(userId: string): Loadout {
+		return new Loadout(userId, new Map());
+	}
+
+	static from(userId: string, items: LoadoutItem[]): Loadout {
+		return new Loadout(userId, new Map(items.map((item) => [item.cosmeticType, item.cosmeticId])));
+	}
+
+	equip(cosmeticType: CosmeticType, cosmeticId: string): void {
+		this.equipped.set(cosmeticType, cosmeticId);
+	}
+
+	equippedCosmeticId(cosmeticType: CosmeticType): string | null {
+		return this.equipped.get(cosmeticType) ?? null;
+	}
+
+	items(): LoadoutItem[] {
+		return Array.from(this.equipped, ([cosmeticType, cosmeticId]) => ({ cosmeticType, cosmeticId }));
+	}
+}

--- a/src/modules/loadout/domain/LoadoutRepository.ts
+++ b/src/modules/loadout/domain/LoadoutRepository.ts
@@ -1,0 +1,6 @@
+import { Loadout } from "./Loadout";
+
+export interface LoadoutRepository {
+	findByUserId(userId: string): Promise<Loadout>;
+	save(loadout: Loadout): Promise<void>;
+}

--- a/src/modules/loadout/infrastructure/LoadoutPostgresRepository.ts
+++ b/src/modules/loadout/infrastructure/LoadoutPostgresRepository.ts
@@ -1,0 +1,34 @@
+import { cosmeticsDataSource } from "../../../cosmetics-data-source";
+import { Loadout } from "../domain/Loadout";
+import { LoadoutRepository } from "../domain/LoadoutRepository";
+import { UserLoadoutEntity } from "./UserLoadoutEntity";
+
+export class LoadoutPostgresRepository implements LoadoutRepository {
+	async findByUserId(userId: string): Promise<Loadout> {
+		const repository = cosmeticsDataSource.getRepository(UserLoadoutEntity);
+		const rows = await repository.find({ where: { userId } });
+
+		return Loadout.from(
+			userId,
+			rows.map((row) => ({ cosmeticType: row.cosmeticType, cosmeticId: row.cosmeticId })),
+		);
+	}
+
+	async save(loadout: Loadout): Promise<void> {
+		const repository = cosmeticsDataSource.getRepository(UserLoadoutEntity);
+		const entities = loadout.items().map((item) =>
+			repository.create({
+				userId: loadout.userId,
+				cosmeticType: item.cosmeticType,
+				cosmeticId: item.cosmeticId,
+			}),
+		);
+
+		if (entities.length === 0) {
+			return;
+		}
+
+		// Upsert by the composite primary key (user_id, cosmetic_type).
+		await repository.save(entities);
+	}
+}

--- a/tests/unit/modules/entitlements/domain/Entitlement.test.ts
+++ b/tests/unit/modules/entitlements/domain/Entitlement.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+
+import { Entitlement } from "../../../../../src/modules/entitlements/domain/Entitlement";
+import { EntitlementSource } from "../../../../../src/modules/entitlements/domain/EntitlementSource";
+import { GrantType } from "../../../../../src/modules/entitlements/domain/GrantType";
+
+function tierGrant(expiresAt: Date | null): Entitlement {
+	return Entitlement.create({
+		id: "ent-1",
+		userId: "user-1",
+		grantType: GrantType.TIER,
+		grantValue: "REGISTERED",
+		source: EntitlementSource.REGISTRATION,
+		expiresAt,
+	});
+}
+
+describe("Entitlement", () => {
+	it("is active when it has no expiration", () => {
+		expect(tierGrant(null).isActiveAt(new Date("2026-06-08T00:00:00Z"))).toBe(true);
+	});
+
+	it("is active before its expiration and inactive once expired", () => {
+		const entitlement = tierGrant(new Date("2026-07-01T00:00:00Z"));
+
+		expect(entitlement.isActiveAt(new Date("2026-06-08T00:00:00Z"))).toBe(true);
+		expect(entitlement.isActiveAt(new Date("2026-08-01T00:00:00Z"))).toBe(false);
+	});
+});

--- a/tests/unit/modules/loadout/domain/Loadout.test.ts
+++ b/tests/unit/modules/loadout/domain/Loadout.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+
+import { CosmeticType } from "../../../../../src/modules/catalog/domain/CosmeticType";
+import { Loadout } from "../../../../../src/modules/loadout/domain/Loadout";
+
+describe("Loadout", () => {
+	it("starts empty and equips one cosmetic per slot", () => {
+		const loadout = Loadout.empty("user-1");
+		loadout.equip(CosmeticType.SLEEVE, "sleeve-1");
+
+		expect(loadout.equippedCosmeticId(CosmeticType.SLEEVE)).toBe("sleeve-1");
+		expect(loadout.equippedCosmeticId(CosmeticType.PLAYMAT)).toBeNull();
+	});
+
+	it("replaces the cosmetic in a slot when equipping again", () => {
+		const loadout = Loadout.empty("user-1");
+		loadout.equip(CosmeticType.SLEEVE, "sleeve-1");
+		loadout.equip(CosmeticType.SLEEVE, "sleeve-2");
+
+		expect(loadout.equippedCosmeticId(CosmeticType.SLEEVE)).toBe("sleeve-2");
+		expect(loadout.items()).toHaveLength(1);
+	});
+
+	it("reconstructs from persisted rows and exposes its items", () => {
+		const loadout = Loadout.from("user-1", [
+			{ cosmeticType: CosmeticType.SLEEVE, cosmeticId: "sleeve-1" },
+			{ cosmeticType: CosmeticType.PLAYMAT, cosmeticId: "playmat-1" },
+		]);
+
+		expect(loadout.userId).toBe("user-1");
+		expect(loadout.items()).toHaveLength(2);
+		expect(loadout.equippedCosmeticId(CosmeticType.PLAYMAT)).toBe("playmat-1");
+	});
+});


### PR DESCRIPTION
## Summary
Adds the loadout and entitlements bounded contexts — the domain and persistence building blocks the cosmetics equipping and access flows are built on.

- **Loadout** aggregate: a user's active selection, at most one cosmetic equipped per slot (cosmetic type). Includes its repository port and a Postgres adapter that upserts by the composite primary key `(user_id, cosmetic_type)`.
- **Entitlement** model: a granted access right (a tier or a specific cosmetic) with an optional expiry and a `source` (where it came from). Includes its repository port and Postgres adapter.

Equipping endpoints and the access policy that reads entitlements are built on top of these later, so there is intentionally no use case wired up here yet.

## Changes
| File | Change |
|------|--------|
| `src/modules/loadout/domain/Loadout.ts` | Loadout aggregate (one cosmetic per slot) |
| `src/modules/loadout/domain/LoadoutRepository.ts` | Repository port |
| `src/modules/loadout/infrastructure/LoadoutPostgresRepository.ts` | Postgres adapter (composite-key upsert) |
| `src/modules/entitlements/domain/Entitlement.ts` | Entitlement model (`isActiveAt`) |
| `src/modules/entitlements/domain/EntitlementRepository.ts` | Repository port |
| `src/modules/entitlements/infrastructure/EntitlementPostgresRepository.ts` | Postgres adapter |
| `tests/unit/modules/loadout/domain/Loadout.test.ts` | Loadout domain tests |
| `tests/unit/modules/entitlements/domain/Entitlement.test.ts` | Entitlement domain tests |

## Test Plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
- [x] `bun test` — all green
- [x] Adapters verified against a real Postgres 16 (ephemeral container): re-equipping a slot upserts in place (one row, replaced cosmetic) honoring the foreign keys to `users` and `cosmetics`; entitlements persist and read back by user.
