### PR TITLE
feat(catalog): add public GET /cosmetics endpoint with signed asset manifests

### DIFF
--- a/src/modules/assets/domain/AssetUrlSigner.ts
+++ b/src/modules/assets/domain/AssetUrlSigner.ts
@@ -4,4 +4,12 @@ export interface AssetUrlSigner {
 
 	/** Signs many asset references at once, keyed by their reference. */
 	signMany(assetRefs: string[]): Record<string, string>;
+
+	/**
+	 * Signs every object under a folder prefix, keyed by its path relative to the
+	 * prefix (e.g. "render.jpg", "model.gltf"). Async because it lists the bucket.
+	 * Lets clients fetch a multi-file asset (a gltf plus its .bin/texture, or a
+	 * sleeve's render + preview) whose parts each need their own signed URL.
+	 */
+	signManifest(prefix: string): Promise<Record<string, string>>;
 }

--- a/src/modules/assets/infrastructure/R2AssetUrlSigner.ts
+++ b/src/modules/assets/infrastructure/R2AssetUrlSigner.ts
@@ -22,4 +22,20 @@ export class R2AssetUrlSigner implements AssetUrlSigner {
 	signMany(assetRefs: string[]): Record<string, string> {
 		return Object.fromEntries(assetRefs.map((ref) => [ref, this.sign(ref)]));
 	}
+
+	async signManifest(prefix: string): Promise<Record<string, string>> {
+		const listed = await this.client.list({ prefix });
+
+		const manifest: Record<string, string> = {};
+		for (const object of listed.contents ?? []) {
+			const key = object.key;
+			// Skip the folder placeholder some tools create for an empty prefix.
+			if (!key || key.endsWith("/")) {
+				continue;
+			}
+			manifest[key.slice(prefix.length)] = this.sign(key);
+		}
+
+		return manifest;
+	}
 }

--- a/src/modules/catalog/application/GetCosmeticsCatalog.ts
+++ b/src/modules/catalog/application/GetCosmeticsCatalog.ts
@@ -1,0 +1,45 @@
+import { AssetUrlSigner } from "../../assets/domain/AssetUrlSigner";
+import { CosmeticRepository } from "../domain/CosmeticRepository";
+import { CosmeticTier } from "../domain/CosmeticTier";
+import { CosmeticType } from "../domain/CosmeticType";
+
+export interface CatalogCosmetic {
+	id: string;
+	type: CosmeticType;
+	tier: CosmeticTier;
+	displayName: string;
+	assets: Record<string, string>;
+}
+
+export interface CatalogFilters {
+	type?: CosmeticType;
+	tier?: CosmeticTier;
+}
+
+export class GetCosmeticsCatalog {
+	constructor(
+		private readonly repository: CosmeticRepository,
+		private readonly signer: AssetUrlSigner,
+	) {}
+
+	async run(filters: CatalogFilters = {}): Promise<CatalogCosmetic[]> {
+		const cosmetics = await this.repository.findAll();
+
+		const visible = cosmetics.filter(
+			(cosmetic) =>
+				cosmetic.active &&
+				(filters.type === undefined || cosmetic.type === filters.type) &&
+				(filters.tier === undefined || cosmetic.tier === filters.tier),
+		);
+
+		return Promise.all(
+			visible.map(async (cosmetic) => ({
+				id: cosmetic.id,
+				type: cosmetic.type,
+				tier: cosmetic.tier,
+				displayName: cosmetic.displayName,
+				assets: await this.signer.signManifest(cosmetic.assetRef),
+			})),
+		);
+	}
+}

--- a/src/server/routes/cosmetics-router.ts
+++ b/src/server/routes/cosmetics-router.ts
@@ -1,0 +1,29 @@
+import { Elysia, t } from "elysia";
+
+import { createR2AssetUrlSigner } from "../../modules/assets/infrastructure/createR2AssetUrlSigner";
+import { GetCosmeticsCatalog } from "../../modules/catalog/application/GetCosmeticsCatalog";
+import { CosmeticTier } from "../../modules/catalog/domain/CosmeticTier";
+import { CosmeticType } from "../../modules/catalog/domain/CosmeticType";
+import { CosmeticPostgresRepository } from "../../modules/catalog/infrastructure/CosmeticPostgresRepository";
+
+const getCosmeticsCatalog = new GetCosmeticsCatalog(
+	new CosmeticPostgresRepository(),
+	createR2AssetUrlSigner(),
+);
+
+export const cosmeticsRouter = new Elysia({ prefix: "/cosmetics" }).get(
+	"/",
+	({ query }) => getCosmeticsCatalog.run({ type: query.type, tier: query.tier }),
+	{
+		query: t.Object({
+			type: t.Optional(t.Enum(CosmeticType)),
+			tier: t.Optional(t.Enum(CosmeticTier)),
+		}),
+		detail: {
+			tags: ["Cosmetics"],
+			summary: "List the cosmetics catalog",
+			description:
+				"Public catalog of cosmetics, filterable by type and tier. Each item includes a manifest of short-lived signed URLs, one per asset file under the cosmetic's storage prefix.",
+		},
+	},
+);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,6 +9,7 @@ import { NotFoundError } from "../shared/errors/NotFoundError";
 import { Logger } from "../shared/logger/domain/Logger";
 
 import { banListRouter } from "./routes/ban-list-router";
+import { cosmeticsRouter } from "./routes/cosmetics-router";
 import { leaderboardRouter } from "./routes/leaderboard-router";
 import { statsRouter } from "./routes/stats-router";
 import { ticketRouter } from "./routes/ticket-router";
@@ -75,6 +76,10 @@ export class Server {
 						{
 							name: 'Statistics',
 							description: 'Global statistics and historical data'
+						},
+						{
+							name: 'Cosmetics',
+							description: 'Cosmetics catalog and customization'
 						}
 					],
 					components: {
@@ -117,6 +122,7 @@ export class Server {
 				.use(statsRouter)
 				.use(wrappedRouter)
 				.use(ticketRouter)
+				.use(cosmeticsRouter)
 
 		});
 		this.logger = logger;

--- a/tests/unit/modules/catalog/application/GetCosmeticsCatalog.test.ts
+++ b/tests/unit/modules/catalog/application/GetCosmeticsCatalog.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+
+import { GetCosmeticsCatalog } from "../../../../../src/modules/catalog/application/GetCosmeticsCatalog";
+import { Cosmetic } from "../../../../../src/modules/catalog/domain/Cosmetic";
+import { CosmeticRepository } from "../../../../../src/modules/catalog/domain/CosmeticRepository";
+import { CosmeticTier } from "../../../../../src/modules/catalog/domain/CosmeticTier";
+import { CosmeticType } from "../../../../../src/modules/catalog/domain/CosmeticType";
+import { AssetUrlSigner } from "../../../../../src/modules/assets/domain/AssetUrlSigner";
+
+const sleeve = Cosmetic.from({
+	id: "1",
+	type: CosmeticType.SLEEVE,
+	tier: CosmeticTier.STANDARD,
+	assetRef: "sleeves/a/",
+	displayName: "A",
+	active: true,
+});
+const playmat = Cosmetic.from({
+	id: "2",
+	type: CosmeticType.PLAYMAT,
+	tier: CosmeticTier.REGISTERED,
+	assetRef: "playmats/b/",
+	displayName: "B",
+	active: true,
+});
+const inactive = Cosmetic.from({
+	id: "3",
+	type: CosmeticType.SLEEVE,
+	tier: CosmeticTier.STANDARD,
+	assetRef: "sleeves/c/",
+	displayName: "C",
+	active: false,
+});
+
+function catalogOf(cosmetics: Cosmetic[]): GetCosmeticsCatalog {
+	const repository: CosmeticRepository = {
+		findAll: async () => cosmetics,
+		save: async () => undefined,
+	};
+	const signer: AssetUrlSigner = {
+		sign: () => "",
+		signMany: () => ({}),
+		signManifest: async (prefix) => ({ "render.jpg": `signed:${prefix}render.jpg` }),
+	};
+
+	return new GetCosmeticsCatalog(repository, signer);
+}
+
+describe("GetCosmeticsCatalog", () => {
+	it("returns active cosmetics with their signed asset manifest", async () => {
+		const result = await catalogOf([sleeve, playmat]).run();
+
+		expect(result).toHaveLength(2);
+		expect(result[0].assets).toEqual({ "render.jpg": "signed:sleeves/a/render.jpg" });
+	});
+
+	it("excludes inactive cosmetics", async () => {
+		const result = await catalogOf([sleeve, inactive]).run();
+
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("1");
+	});
+
+	it("filters by type", async () => {
+		const result = await catalogOf([sleeve, playmat]).run({ type: CosmeticType.PLAYMAT });
+
+		expect(result).toHaveLength(1);
+		expect(result[0].type).toBe(CosmeticType.PLAYMAT);
+	});
+
+	it("filters by tier", async () => {
+		const result = await catalogOf([sleeve, playmat]).run({ tier: CosmeticTier.STANDARD });
+
+		expect(result).toHaveLength(1);
+		expect(result[0].tier).toBe(CosmeticTier.STANDARD);
+	});
+});


### PR DESCRIPTION
## Summary
Exposes the cosmetics catalog over a public, filterable HTTP endpoint — the first endpoint of the cosmetics feature.

- `GET /api/v1/cosmetics` returns active cosmetics, optionally filtered by `type` and `tier`. Public (no auth).
- Each item carries a **manifest of short-lived signed URLs**, one per file under its storage prefix, so multi-file assets can each be fetched directly from the private bucket (a sleeve's `render` + `preview`; a playmat's model + geometry + texture).
- Extends the asset signer with `signManifest(prefix)`: lists the prefix and signs every object under it (async, since listing hits the bucket).

## Changes
| File | Change |
|------|--------|
| `src/modules/assets/domain/AssetUrlSigner.ts` | Add `signManifest` to the port |
| `src/modules/assets/infrastructure/R2AssetUrlSigner.ts` | Implement `signManifest` (list + sign each object) |
| `src/modules/catalog/application/GetCosmeticsCatalog.ts` | Use case: active cosmetics + filters + per-item manifest |
| `src/server/routes/cosmetics-router.ts` | Public `GET /cosmetics` route (type/tier query) |
| `src/server/server.ts` | Register the router and add the Cosmetics tag |
| `tests/unit/modules/catalog/application/GetCosmeticsCatalog.test.ts` | Use-case tests |

## Test Plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
- [x] `bun test` — all green
- [x] Verified end-to-end against the real private bucket + a seeded Postgres: the use case returned all 8 cosmetics, each with the complete file manifest (sleeve → `render.jpg`/`preview.jpg`; playmat → `.gltf`/`.bin`/texture), and fetching a signed URL returned `200` with the real binary (image/jpeg and application/octet-stream).
