### PR TITLE
feat(entitlements): add the cosmetics access gate with a derived tier

### DIFF
--- a/src/modules/entitlements/application/EntitlementsGatekeeper.ts
+++ b/src/modules/entitlements/application/EntitlementsGatekeeper.ts
@@ -1,0 +1,35 @@
+import { CosmeticTier } from "../../catalog/domain/CosmeticTier";
+import { tierGrants } from "../domain/accessTier";
+import { EntitlementRepository } from "../domain/EntitlementRepository";
+import { GrantType } from "../domain/GrantType";
+
+// The single access gate for cosmetics. Every access check must pass through here
+// — callers never compare tiers themselves (RFC §8). Today it resolves an ordinal
+// tier; new access sources (purchases, donation ranks) plug in here without
+// changing any caller.
+export class EntitlementsGatekeeper {
+	constructor(private readonly entitlements: EntitlementRepository) {}
+
+	async canUse(
+		userId: string,
+		cosmetic: { tier: CosmeticTier },
+		at: Date = new Date(),
+	): Promise<boolean> {
+		const userTier = await this.deriveTier(userId, at);
+		return tierGrants(userTier, cosmetic.tier);
+	}
+
+	private async deriveTier(userId: string, at: Date): Promise<CosmeticTier> {
+		const granted = await this.entitlements.findByUserId(userId);
+
+		const isDonor = granted.some(
+			(entitlement) =>
+				entitlement.grantType === GrantType.TIER &&
+				entitlement.grantValue === CosmeticTier.DONOR &&
+				entitlement.isActiveAt(at),
+		);
+
+		// Authenticated users are registered at minimum; donor when actively granted.
+		return isDonor ? CosmeticTier.DONOR : CosmeticTier.REGISTERED;
+	}
+}

--- a/src/modules/entitlements/domain/accessTier.ts
+++ b/src/modules/entitlements/domain/accessTier.ts
@@ -1,0 +1,13 @@
+import { CosmeticTier } from "../../catalog/domain/CosmeticTier";
+
+// Ordinal ranking of access tiers. Access is gated "ordinal-first" (RFC §12):
+// a user tier grants every cosmetic tier at or below it.
+const RANK: Record<CosmeticTier, number> = {
+	[CosmeticTier.STANDARD]: 0,
+	[CosmeticTier.REGISTERED]: 1,
+	[CosmeticTier.DONOR]: 2,
+};
+
+export function tierGrants(userTier: CosmeticTier, requiredTier: CosmeticTier): boolean {
+	return RANK[userTier] >= RANK[requiredTier];
+}

--- a/tests/unit/modules/entitlements/application/EntitlementsGatekeeper.test.ts
+++ b/tests/unit/modules/entitlements/application/EntitlementsGatekeeper.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+
+import { CosmeticTier } from "../../../../../src/modules/catalog/domain/CosmeticTier";
+import { Entitlement } from "../../../../../src/modules/entitlements/domain/Entitlement";
+import { EntitlementRepository } from "../../../../../src/modules/entitlements/domain/EntitlementRepository";
+import { EntitlementSource } from "../../../../../src/modules/entitlements/domain/EntitlementSource";
+import { GrantType } from "../../../../../src/modules/entitlements/domain/GrantType";
+import { EntitlementsGatekeeper } from "../../../../../src/modules/entitlements/application/EntitlementsGatekeeper";
+
+const NOW = new Date("2026-06-08T00:00:00Z");
+
+function gatekeeper(entitlements: Entitlement[]): EntitlementsGatekeeper {
+	const repository: EntitlementRepository = {
+		findByUserId: async () => entitlements,
+		save: async () => undefined,
+	};
+
+	return new EntitlementsGatekeeper(repository);
+}
+
+function donorGrant(expiresAt: Date | null): Entitlement {
+	return Entitlement.create({
+		id: "e1",
+		userId: "user-1",
+		grantType: GrantType.TIER,
+		grantValue: CosmeticTier.DONOR,
+		source: EntitlementSource.DONATION,
+		expiresAt,
+	});
+}
+
+describe("EntitlementsGatekeeper", () => {
+	it("lets a registered user (no donor grant) use standard and registered cosmetics, but not donor", async () => {
+		const gk = gatekeeper([]);
+
+		expect(await gk.canUse("user-1", { tier: CosmeticTier.STANDARD }, NOW)).toBe(true);
+		expect(await gk.canUse("user-1", { tier: CosmeticTier.REGISTERED }, NOW)).toBe(true);
+		expect(await gk.canUse("user-1", { tier: CosmeticTier.DONOR }, NOW)).toBe(false);
+	});
+
+	it("lets a user with an active donor grant use donor cosmetics", async () => {
+		const gk = gatekeeper([donorGrant(null)]);
+
+		expect(await gk.canUse("user-1", { tier: CosmeticTier.DONOR }, NOW)).toBe(true);
+	});
+
+	it("ignores an expired donor grant", async () => {
+		const gk = gatekeeper([donorGrant(new Date("2026-01-01T00:00:00Z"))]);
+
+		expect(await gk.canUse("user-1", { tier: CosmeticTier.DONOR }, NOW)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
Adds the single access gate every cosmetic access check goes through, so callers never compare tiers themselves.

- `canUse(user, cosmetic)` resolves the user's access tier — **registered** by default (authenticated users have an account), **donor** when an active donor grant exists — and grants access **ordinally**: a tier covers every cosmetic tier at or below it.
- The gate is the only place that knows the access rule. New access sources (purchases, donation ranks) plug in here later without touching any caller.

This is the building block the equipping flow validates against. There is no endpoint here yet — it is consumed by the loadout `PUT` next.

## Changes
| File | Change |
|------|--------|
| `src/modules/entitlements/domain/accessTier.ts` | Ordinal tier ranking |
| `src/modules/entitlements/application/EntitlementsGatekeeper.ts` | `canUse` gate with derived tier |
| `tests/unit/modules/entitlements/application/EntitlementsGatekeeper.test.ts` | Gate tests |

## Test Plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
- [x] `bun test` — all green (registered user can use standard/registered but not donor; active donor grant unlocks donor; expired donor grant is ignored)
