### PR TITLE
feat(loadout): add GET/PUT /me/loadout endpoints with entitlement validation

### DIFF
--- a/src/modules/catalog/domain/CosmeticRepository.ts
+++ b/src/modules/catalog/domain/CosmeticRepository.ts
@@ -2,5 +2,6 @@ import { Cosmetic } from "./Cosmetic";
 
 export interface CosmeticRepository {
 	findAll(): Promise<Cosmetic[]>;
+	findById(id: string): Promise<Cosmetic | null>;
 	save(cosmetic: Cosmetic): Promise<void>;
 }

--- a/src/modules/catalog/infrastructure/CosmeticPostgresRepository.ts
+++ b/src/modules/catalog/infrastructure/CosmeticPostgresRepository.ts
@@ -20,6 +20,24 @@ export class CosmeticPostgresRepository implements CosmeticRepository {
 		);
 	}
 
+	async findById(id: string): Promise<Cosmetic | null> {
+		const repository = cosmeticsDataSource.getRepository(CosmeticEntity);
+		const entity = await repository.findOne({ where: { id } });
+
+		if (!entity) {
+			return null;
+		}
+
+		return Cosmetic.from({
+			id: entity.id,
+			type: entity.type,
+			tier: entity.tier,
+			assetRef: entity.assetRef,
+			displayName: entity.displayName,
+			active: entity.active,
+		});
+	}
+
 	async save(cosmetic: Cosmetic): Promise<void> {
 		const repository = cosmeticsDataSource.getRepository(CosmeticEntity);
 		const data = cosmetic.toPrimitives();

--- a/src/modules/loadout/application/EquipCosmetic.ts
+++ b/src/modules/loadout/application/EquipCosmetic.ts
@@ -1,0 +1,41 @@
+import { ForbiddenError } from "../../../shared/errors/ForbiddenError";
+import { InvalidArgumentError } from "../../../shared/errors/InvalidArgumentError";
+import { NotFoundError } from "../../../shared/errors/NotFoundError";
+import { CosmeticRepository } from "../../catalog/domain/CosmeticRepository";
+import { CosmeticType } from "../../catalog/domain/CosmeticType";
+import { EntitlementsGatekeeper } from "../../entitlements/application/EntitlementsGatekeeper";
+import { LoadoutRepository } from "../domain/LoadoutRepository";
+
+export class EquipCosmetic {
+	constructor(
+		private readonly cosmetics: CosmeticRepository,
+		private readonly loadouts: LoadoutRepository,
+		private readonly gatekeeper: EntitlementsGatekeeper,
+	) {}
+
+	async run({
+		userId,
+		cosmeticType,
+		cosmeticId,
+	}: {
+		userId: string;
+		cosmeticType: CosmeticType;
+		cosmeticId: string;
+	}): Promise<void> {
+		const cosmetic = await this.cosmetics.findById(cosmeticId);
+		if (!cosmetic) {
+			throw new NotFoundError(`Cosmetic ${cosmeticId} not found`);
+		}
+		if (cosmetic.type !== cosmeticType) {
+			throw new InvalidArgumentError(`Cosmetic ${cosmeticId} cannot be equipped in the ${cosmeticType} slot`);
+		}
+		// Access is always decided by the gate — never compared here (RFC §8).
+		if (!(await this.gatekeeper.canUse(userId, cosmetic))) {
+			throw new ForbiddenError(`User is not entitled to cosmetic ${cosmeticId}`);
+		}
+
+		const loadout = await this.loadouts.findByUserId(userId);
+		loadout.equip(cosmeticType, cosmeticId);
+		await this.loadouts.save(loadout);
+	}
+}

--- a/src/modules/loadout/application/GetMyLoadout.ts
+++ b/src/modules/loadout/application/GetMyLoadout.ts
@@ -1,0 +1,33 @@
+import { AssetUrlSigner } from "../../assets/domain/AssetUrlSigner";
+import { CosmeticRepository } from "../../catalog/domain/CosmeticRepository";
+import { CosmeticType } from "../../catalog/domain/CosmeticType";
+import { LoadoutRepository } from "../domain/LoadoutRepository";
+
+export interface MyLoadoutSlot {
+	cosmeticType: CosmeticType;
+	cosmeticId: string;
+	assets: Record<string, string>;
+}
+
+export class GetMyLoadout {
+	constructor(
+		private readonly loadouts: LoadoutRepository,
+		private readonly cosmetics: CosmeticRepository,
+		private readonly signer: AssetUrlSigner,
+	) {}
+
+	async run(userId: string): Promise<MyLoadoutSlot[]> {
+		const loadout = await this.loadouts.findByUserId(userId);
+
+		return Promise.all(
+			loadout.items().map(async (item) => {
+				const cosmetic = await this.cosmetics.findById(item.cosmeticId);
+				return {
+					cosmeticType: item.cosmeticType,
+					cosmeticId: item.cosmeticId,
+					assets: cosmetic ? await this.signer.signManifest(cosmetic.assetRef) : {},
+				};
+			}),
+		);
+	}
+}

--- a/src/server/routes/loadout-router.ts
+++ b/src/server/routes/loadout-router.ts
@@ -1,0 +1,63 @@
+import { bearer } from "@elysiajs/bearer";
+import { Elysia, t } from "elysia";
+
+import { config } from "../../config";
+import { createR2AssetUrlSigner } from "../../modules/assets/infrastructure/createR2AssetUrlSigner";
+import { CosmeticType } from "../../modules/catalog/domain/CosmeticType";
+import { CosmeticPostgresRepository } from "../../modules/catalog/infrastructure/CosmeticPostgresRepository";
+import { EntitlementsGatekeeper } from "../../modules/entitlements/application/EntitlementsGatekeeper";
+import { EntitlementPostgresRepository } from "../../modules/entitlements/infrastructure/EntitlementPostgresRepository";
+import { EquipCosmetic } from "../../modules/loadout/application/EquipCosmetic";
+import { GetMyLoadout } from "../../modules/loadout/application/GetMyLoadout";
+import { LoadoutPostgresRepository } from "../../modules/loadout/infrastructure/LoadoutPostgresRepository";
+import { JWT } from "../../shared/JWT";
+
+const jwt = new JWT(config.jwt);
+const cosmetics = new CosmeticPostgresRepository();
+const loadouts = new LoadoutPostgresRepository();
+const gatekeeper = new EntitlementsGatekeeper(new EntitlementPostgresRepository());
+
+const getMyLoadout = new GetMyLoadout(loadouts, cosmetics, createR2AssetUrlSigner());
+const equipCosmetic = new EquipCosmetic(cosmetics, loadouts, gatekeeper);
+
+export const loadoutRouter = new Elysia({ prefix: "/me/loadout" })
+	.use(bearer())
+	.get(
+		"/",
+		({ bearer }) => {
+			const { id } = jwt.decode(bearer as string) as { id: string };
+			return getMyLoadout.run(id);
+		},
+		{
+			detail: {
+				tags: ["Cosmetics"],
+				summary: "Get my loadout",
+				description: "Returns the authenticated user's equipped cosmetics with signed asset URLs.",
+				security: [{ bearerAuth: [] }],
+			},
+		},
+	)
+	.put(
+		"/",
+		async ({ bearer, body }) => {
+			const { id } = jwt.decode(bearer as string) as { id: string };
+			await equipCosmetic.run({
+				userId: id,
+				cosmeticType: body.cosmeticType,
+				cosmeticId: body.cosmeticId,
+			});
+			return getMyLoadout.run(id);
+		},
+		{
+			body: t.Object({
+				cosmeticType: t.Enum(CosmeticType),
+				cosmeticId: t.String(),
+			}),
+			detail: {
+				tags: ["Cosmetics"],
+				summary: "Equip a cosmetic",
+				description: "Equips a cosmetic in its slot after validating the user is entitled to it.",
+				security: [{ bearerAuth: [] }],
+			},
+		},
+	);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4,6 +4,7 @@ import { Elysia } from "elysia";
 
 import { AuthenticationError } from "../shared/errors/AuthenticationError";
 import { ConflictError } from "../shared/errors/ConflictError";
+import { ForbiddenError } from "../shared/errors/ForbiddenError";
 import { InvalidArgumentError } from "../shared/errors/InvalidArgumentError";
 import { NotFoundError } from "../shared/errors/NotFoundError";
 import { Logger } from "../shared/logger/domain/Logger";
@@ -11,6 +12,7 @@ import { Logger } from "../shared/logger/domain/Logger";
 import { banListRouter } from "./routes/ban-list-router";
 import { cosmeticsRouter } from "./routes/cosmetics-router";
 import { leaderboardRouter } from "./routes/leaderboard-router";
+import { loadoutRouter } from "./routes/loadout-router";
 import { statsRouter } from "./routes/stats-router";
 import { ticketRouter } from "./routes/ticket-router";
 import { tournamentRouter } from "./routes/tournament-router";
@@ -110,6 +112,10 @@ export class Server {
 				if (error instanceof InvalidArgumentError) {
 					set.status = 400;
 				}
+
+				if (error instanceof ForbiddenError) {
+					set.status = 403;
+				}
 			});
 
 		// @ts-expect-error linter not config correctly
@@ -123,6 +129,7 @@ export class Server {
 				.use(wrappedRouter)
 				.use(ticketRouter)
 				.use(cosmeticsRouter)
+				.use(loadoutRouter)
 
 		});
 		this.logger = logger;

--- a/src/shared/errors/ForbiddenError.ts
+++ b/src/shared/errors/ForbiddenError.ts
@@ -1,0 +1,6 @@
+export class ForbiddenError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ForbiddenError";
+	}
+}

--- a/tests/unit/modules/catalog/application/GetCosmeticsCatalog.test.ts
+++ b/tests/unit/modules/catalog/application/GetCosmeticsCatalog.test.ts
@@ -35,6 +35,7 @@ const inactive = Cosmetic.from({
 function catalogOf(cosmetics: Cosmetic[]): GetCosmeticsCatalog {
 	const repository: CosmeticRepository = {
 		findAll: async () => cosmetics,
+		findById: async () => null,
 		save: async () => undefined,
 	};
 	const signer: AssetUrlSigner = {

--- a/tests/unit/modules/catalog/application/SeedStandardCosmetics.test.ts
+++ b/tests/unit/modules/catalog/application/SeedStandardCosmetics.test.ts
@@ -9,6 +9,7 @@ function fakeRepository(existing: Cosmetic[]): { repository: CosmeticRepository;
 	const saved: Cosmetic[] = [];
 	const repository: CosmeticRepository = {
 		findAll: async () => existing,
+		findById: async () => null,
 		save: async (cosmetic) => {
 			saved.push(cosmetic);
 		},

--- a/tests/unit/modules/loadout/application/EquipCosmetic.test.ts
+++ b/tests/unit/modules/loadout/application/EquipCosmetic.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+
+import { Cosmetic } from "../../../../../src/modules/catalog/domain/Cosmetic";
+import { CosmeticRepository } from "../../../../../src/modules/catalog/domain/CosmeticRepository";
+import { CosmeticTier } from "../../../../../src/modules/catalog/domain/CosmeticTier";
+import { CosmeticType } from "../../../../../src/modules/catalog/domain/CosmeticType";
+import { EntitlementsGatekeeper } from "../../../../../src/modules/entitlements/application/EntitlementsGatekeeper";
+import { Entitlement } from "../../../../../src/modules/entitlements/domain/Entitlement";
+import { EquipCosmetic } from "../../../../../src/modules/loadout/application/EquipCosmetic";
+import { Loadout } from "../../../../../src/modules/loadout/domain/Loadout";
+import { LoadoutRepository } from "../../../../../src/modules/loadout/domain/LoadoutRepository";
+import { ForbiddenError } from "../../../../../src/shared/errors/ForbiddenError";
+import { InvalidArgumentError } from "../../../../../src/shared/errors/InvalidArgumentError";
+import { NotFoundError } from "../../../../../src/shared/errors/NotFoundError";
+
+function cosmetic(tier: CosmeticTier): Cosmetic {
+	return Cosmetic.from({
+		id: "cosmetic-1",
+		type: CosmeticType.SLEEVE,
+		tier,
+		assetRef: "sleeves/a/",
+		displayName: "A",
+		active: true,
+	});
+}
+
+function build(options: { found: Cosmetic | null; entitlements?: Entitlement[] }) {
+	const cosmetics: CosmeticRepository = {
+		findAll: async () => [],
+		findById: async (id) => (options.found && options.found.id === id ? options.found : null),
+		save: async () => undefined,
+	};
+
+	const saved: Loadout[] = [];
+	const loadouts: LoadoutRepository = {
+		findByUserId: async (userId) => Loadout.empty(userId),
+		save: async (loadout) => {
+			saved.push(loadout);
+		},
+	};
+
+	// Real gatekeeper over a fake entitlement repository.
+	const gatekeeper = new EntitlementsGatekeeper({
+		findByUserId: async () => options.entitlements ?? [],
+		save: async () => undefined,
+	});
+
+	return { equip: new EquipCosmetic(cosmetics, loadouts, gatekeeper), saved };
+}
+
+describe("EquipCosmetic", () => {
+	it("equips a cosmetic the user is entitled to", async () => {
+		const { equip, saved } = build({ found: cosmetic(CosmeticTier.REGISTERED) });
+
+		await equip.run({ userId: "user-1", cosmeticType: CosmeticType.SLEEVE, cosmeticId: "cosmetic-1" });
+
+		expect(saved).toHaveLength(1);
+		expect(saved[0].equippedCosmeticId(CosmeticType.SLEEVE)).toBe("cosmetic-1");
+	});
+
+	it("rejects equipping a cosmetic the user is not entitled to", async () => {
+		const { equip, saved } = build({ found: cosmetic(CosmeticTier.DONOR) });
+
+		await expect(
+			equip.run({ userId: "user-1", cosmeticType: CosmeticType.SLEEVE, cosmeticId: "cosmetic-1" }),
+		).rejects.toBeInstanceOf(ForbiddenError);
+		expect(saved).toHaveLength(0);
+	});
+
+	it("rejects an unknown cosmetic", async () => {
+		const { equip } = build({ found: null });
+
+		await expect(
+			equip.run({ userId: "user-1", cosmeticType: CosmeticType.SLEEVE, cosmeticId: "missing" }),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it("rejects equipping a cosmetic in the wrong slot", async () => {
+		const { equip } = build({ found: cosmetic(CosmeticTier.STANDARD) });
+
+		await expect(
+			equip.run({ userId: "user-1", cosmeticType: CosmeticType.PLAYMAT, cosmeticId: "cosmetic-1" }),
+		).rejects.toBeInstanceOf(InvalidArgumentError);
+	});
+});

--- a/tests/unit/modules/loadout/application/GetMyLoadout.test.ts
+++ b/tests/unit/modules/loadout/application/GetMyLoadout.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+
+import { AssetUrlSigner } from "../../../../../src/modules/assets/domain/AssetUrlSigner";
+import { Cosmetic } from "../../../../../src/modules/catalog/domain/Cosmetic";
+import { CosmeticRepository } from "../../../../../src/modules/catalog/domain/CosmeticRepository";
+import { CosmeticTier } from "../../../../../src/modules/catalog/domain/CosmeticTier";
+import { CosmeticType } from "../../../../../src/modules/catalog/domain/CosmeticType";
+import { GetMyLoadout } from "../../../../../src/modules/loadout/application/GetMyLoadout";
+import { Loadout } from "../../../../../src/modules/loadout/domain/Loadout";
+import { LoadoutRepository } from "../../../../../src/modules/loadout/domain/LoadoutRepository";
+
+const sleeve = Cosmetic.from({
+	id: "cosmetic-1",
+	type: CosmeticType.SLEEVE,
+	tier: CosmeticTier.STANDARD,
+	assetRef: "sleeves/a/",
+	displayName: "A",
+	active: true,
+});
+
+function build(loadout: Loadout) {
+	const loadouts: LoadoutRepository = {
+		findByUserId: async () => loadout,
+		save: async () => undefined,
+	};
+	const cosmetics: CosmeticRepository = {
+		findAll: async () => [sleeve],
+		findById: async (id) => (id === sleeve.id ? sleeve : null),
+		save: async () => undefined,
+	};
+	const signer: AssetUrlSigner = {
+		sign: () => "",
+		signMany: () => ({}),
+		signManifest: async (prefix) => ({ "render.jpg": `signed:${prefix}render.jpg` }),
+	};
+
+	return new GetMyLoadout(loadouts, cosmetics, signer);
+}
+
+describe("GetMyLoadout", () => {
+	it("returns each equipped slot with its signed asset manifest", async () => {
+		const loadout = Loadout.from("user-1", [
+			{ cosmeticType: CosmeticType.SLEEVE, cosmeticId: "cosmetic-1" },
+		]);
+
+		const result = await build(loadout).run("user-1");
+
+		expect(result).toHaveLength(1);
+		expect(result[0].cosmeticType).toBe(CosmeticType.SLEEVE);
+		expect(result[0].cosmeticId).toBe("cosmetic-1");
+		expect(result[0].assets).toEqual({ "render.jpg": "signed:sleeves/a/render.jpg" });
+	});
+
+	it("returns an empty loadout for a user with nothing equipped", async () => {
+		const result = await build(Loadout.empty("user-1")).run("user-1");
+
+		expect(result).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
Lets authenticated users read and change their equipped cosmetics.

- **`GET /api/v1/me/loadout`** returns the user's equipped cosmetics, each slot with a signed asset manifest (reusing the per-prefix signing).
- **`PUT /api/v1/me/loadout`** equips a cosmetic in its slot. It validates server-side, through the single access gate, that the user is entitled to the cosmetic — and that the cosmetic actually matches the slot. Never trusts the client.

Adds a `ForbiddenError` (mapped to `403`) and a `findById` lookup on the cosmetics repository.

## Changes
| File | Change |
|------|--------|
| `src/modules/loadout/application/EquipCosmetic.ts` | Equip use case (existence + slot + access checks) |
| `src/modules/loadout/application/GetMyLoadout.ts` | Read loadout with signed manifests |
| `src/server/routes/loadout-router.ts` | Authenticated `GET`/`PUT /me/loadout` |
| `src/server/server.ts` | Register the router; map `ForbiddenError` → 403 |
| `src/shared/errors/ForbiddenError.ts` | New error type |
| `src/modules/catalog/domain/CosmeticRepository.ts` · `…/CosmeticPostgresRepository.ts` | Add `findById` |
| `tests/unit/modules/loadout/application/*.test.ts` | Use-case tests |

## Test Plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
- [x] `bun test` — all green (equip allowed when entitled; rejected with `ForbiddenError` when not; unknown cosmetic → `NotFoundError`; wrong slot → `InvalidArgumentError`)
- [x] Verified end-to-end against a seeded Postgres + the real private bucket: equipped a sleeve and a playmat (persisted to `user_loadouts`), read them back with full signed manifests, fetched a signed URL (`200 image/jpeg`), and confirmed a wrong-slot equip is rejected.
