### PR TITLE
feat(loadout): add public GET /users/by-username/:username/loadout endpoint

### DIFF
--- a/src/modules/loadout/application/GetPublicLoadout.ts
+++ b/src/modules/loadout/application/GetPublicLoadout.ts
@@ -1,0 +1,22 @@
+import { NotFoundError } from "../../../shared/errors/NotFoundError";
+import { UserDirectory } from "../domain/UserDirectory";
+import { GetMyLoadout, MyLoadoutSlot } from "./GetMyLoadout";
+
+// Public, read-only loadout of a player addressed by username — used to render an
+// opponent's cosmetics during a duel. A missing username is a 404 so the client can
+// fall back to the standard look.
+export class GetPublicLoadout {
+	constructor(
+		private readonly users: UserDirectory,
+		private readonly myLoadout: GetMyLoadout,
+	) {}
+
+	async run(username: string): Promise<MyLoadoutSlot[]> {
+		const userId = await this.users.findUserIdByUsername(username);
+		if (!userId) {
+			throw new NotFoundError(`User ${username} not found`);
+		}
+
+		return this.myLoadout.run(userId);
+	}
+}

--- a/src/modules/loadout/domain/UserDirectory.ts
+++ b/src/modules/loadout/domain/UserDirectory.ts
@@ -1,0 +1,6 @@
+// Resolves a public username to its user id. Loadout only needs this single lookup
+// from the shared user data, so it depends on this narrow port rather than the whole
+// user repository.
+export interface UserDirectory {
+	findUserIdByUsername(username: string): Promise<string | null>;
+}

--- a/src/modules/loadout/infrastructure/UserDirectoryPostgresRepository.ts
+++ b/src/modules/loadout/infrastructure/UserDirectoryPostgresRepository.ts
@@ -1,0 +1,14 @@
+import { dataSource } from "../../../evolution-types/src/data-source";
+import { UserProfileEntity } from "../../../evolution-types/src/entities/UserProfileEntity";
+import { UserDirectory } from "../domain/UserDirectory";
+
+// Reads from the shared user table (evolution-types DataSource) — usernames live
+// there, not in the cosmetics schema.
+export class UserDirectoryPostgresRepository implements UserDirectory {
+	async findUserIdByUsername(username: string): Promise<string | null> {
+		const repository = dataSource.getRepository(UserProfileEntity);
+		const entity = await repository.findOne({ where: { username } });
+
+		return entity?.id ?? null;
+	}
+}

--- a/src/server/routes/public-loadout-router.ts
+++ b/src/server/routes/public-loadout-router.ts
@@ -1,0 +1,26 @@
+import { Elysia } from "elysia";
+
+import { createR2AssetUrlSigner } from "../../modules/assets/infrastructure/createR2AssetUrlSigner";
+import { CosmeticPostgresRepository } from "../../modules/catalog/infrastructure/CosmeticPostgresRepository";
+import { GetMyLoadout } from "../../modules/loadout/application/GetMyLoadout";
+import { GetPublicLoadout } from "../../modules/loadout/application/GetPublicLoadout";
+import { LoadoutPostgresRepository } from "../../modules/loadout/infrastructure/LoadoutPostgresRepository";
+import { UserDirectoryPostgresRepository } from "../../modules/loadout/infrastructure/UserDirectoryPostgresRepository";
+
+const loadouts = new LoadoutPostgresRepository();
+const cosmetics = new CosmeticPostgresRepository();
+const getMyLoadout = new GetMyLoadout(loadouts, cosmetics, createR2AssetUrlSigner());
+const getPublicLoadout = new GetPublicLoadout(new UserDirectoryPostgresRepository(), getMyLoadout);
+
+export const publicLoadoutRouter = new Elysia().get(
+	"/users/by-username/:username/loadout",
+	({ params }) => getPublicLoadout.run(params.username),
+	{
+		detail: {
+			tags: ["Cosmetics"],
+			summary: "Get a user's public loadout by username",
+			description:
+				"Public, read-only loadout of a player addressed by username, with signed asset URLs. Returns 404 if the username does not exist (client falls back to the standard look).",
+		},
+	},
+);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -13,6 +13,7 @@ import { banListRouter } from "./routes/ban-list-router";
 import { cosmeticsRouter } from "./routes/cosmetics-router";
 import { leaderboardRouter } from "./routes/leaderboard-router";
 import { loadoutRouter } from "./routes/loadout-router";
+import { publicLoadoutRouter } from "./routes/public-loadout-router";
 import { statsRouter } from "./routes/stats-router";
 import { ticketRouter } from "./routes/ticket-router";
 import { tournamentRouter } from "./routes/tournament-router";
@@ -130,6 +131,7 @@ export class Server {
 				.use(ticketRouter)
 				.use(cosmeticsRouter)
 				.use(loadoutRouter)
+				.use(publicLoadoutRouter)
 
 		});
 		this.logger = logger;

--- a/tests/unit/modules/loadout/application/GetPublicLoadout.test.ts
+++ b/tests/unit/modules/loadout/application/GetPublicLoadout.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+
+import { AssetUrlSigner } from "../../../../../src/modules/assets/domain/AssetUrlSigner";
+import { Cosmetic } from "../../../../../src/modules/catalog/domain/Cosmetic";
+import { CosmeticRepository } from "../../../../../src/modules/catalog/domain/CosmeticRepository";
+import { CosmeticTier } from "../../../../../src/modules/catalog/domain/CosmeticTier";
+import { CosmeticType } from "../../../../../src/modules/catalog/domain/CosmeticType";
+import { GetMyLoadout } from "../../../../../src/modules/loadout/application/GetMyLoadout";
+import { GetPublicLoadout } from "../../../../../src/modules/loadout/application/GetPublicLoadout";
+import { Loadout } from "../../../../../src/modules/loadout/domain/Loadout";
+import { LoadoutRepository } from "../../../../../src/modules/loadout/domain/LoadoutRepository";
+import { UserDirectory } from "../../../../../src/modules/loadout/domain/UserDirectory";
+import { NotFoundError } from "../../../../../src/shared/errors/NotFoundError";
+
+const sleeve = Cosmetic.from({
+	id: "cosmetic-1",
+	type: CosmeticType.SLEEVE,
+	tier: CosmeticTier.STANDARD,
+	assetRef: "sleeves/a/",
+	displayName: "A",
+	active: true,
+});
+
+function build(directory: UserDirectory): GetPublicLoadout {
+	const loadouts: LoadoutRepository = {
+		findByUserId: async (userId) =>
+			Loadout.from(userId, [{ cosmeticType: CosmeticType.SLEEVE, cosmeticId: "cosmetic-1" }]),
+		save: async () => undefined,
+	};
+	const cosmetics: CosmeticRepository = {
+		findAll: async () => [sleeve],
+		findById: async (id) => (id === sleeve.id ? sleeve : null),
+		save: async () => undefined,
+	};
+	const signer: AssetUrlSigner = {
+		sign: () => "",
+		signMany: () => ({}),
+		signManifest: async (prefix) => ({ "render.jpg": `signed:${prefix}render.jpg` }),
+	};
+
+	return new GetPublicLoadout(directory, new GetMyLoadout(loadouts, cosmetics, signer));
+}
+
+describe("GetPublicLoadout", () => {
+	it("returns the loadout of an existing user by username", async () => {
+		const directory: UserDirectory = {
+			findUserIdByUsername: async (username) => (username === "rival" ? "user-rival" : null),
+		};
+
+		const result = await build(directory).run("rival");
+
+		expect(result).toHaveLength(1);
+		expect(result[0].assets).toEqual({ "render.jpg": "signed:sleeves/a/render.jpg" });
+	});
+
+	it("throws NotFound when the username does not exist (client falls back to standard)", async () => {
+		const directory: UserDirectory = {
+			findUserIdByUsername: async () => null,
+		};
+
+		await expect(build(directory).run("ghost")).rejects.toBeInstanceOf(NotFoundError);
+	});
+});


### PR DESCRIPTION
## Summary
Exposes a player's loadout publicly so an opponent's cosmetics can be rendered during a duel (no game-server changes — the client already knows the opponent's username).

- **`GET /api/v1/users/by-username/:username/loadout`** returns the user's equipped cosmetics with signed asset URLs. Read-only, public.
- A missing username returns **404** so the client falls back to the standard look.
- Resolves the username through a narrow `UserDirectory` port (just username → id), reusing the existing loadout read instead of duplicating it.

## Changes
| File | Change |
|------|--------|
| `src/modules/loadout/domain/UserDirectory.ts` | Narrow port: username → user id |
| `src/modules/loadout/infrastructure/UserDirectoryPostgresRepository.ts` | Adapter over the shared user table |
| `src/modules/loadout/application/GetPublicLoadout.ts` | Resolve username, then reuse the loadout read |
| `src/server/routes/public-loadout-router.ts` | Public route |
| `src/server/server.ts` | Register the router |
| `tests/unit/modules/loadout/application/GetPublicLoadout.test.ts` | Use-case tests |

## Test Plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
- [x] `bun test` — all green (resolves an existing username; throws `NotFoundError` for an unknown one)
- [x] Verified end-to-end against a seeded Postgres (both data sources) + the real private bucket: resolved a username to its loadout with full signed manifests, fetched a signed URL (`200 image/jpeg`), and confirmed an unknown username returns 404.
