### PR TITLE
feat(cosmetics): visibility = usability — personalized catalog + COSMETIC grants (Slice 1)

### DIFF
--- a/src/modules/catalog/application/GetCosmeticsCatalog.ts
+++ b/src/modules/catalog/application/GetCosmeticsCatalog.ts
@@ -1,4 +1,5 @@
 import { AssetUrlSigner } from "../../assets/domain/AssetUrlSigner";
+import { EntitlementsGatekeeper } from "../../entitlements/application/EntitlementsGatekeeper";
 import { CosmeticRepository } from "../domain/CosmeticRepository";
 import { CosmeticTier } from "../domain/CosmeticTier";
 import { CosmeticType } from "../domain/CosmeticType";
@@ -20,14 +21,19 @@ export class GetCosmeticsCatalog {
 	constructor(
 		private readonly repository: CosmeticRepository,
 		private readonly signer: AssetUrlSigner,
+		private readonly gatekeeper: EntitlementsGatekeeper,
 	) {}
 
-	async run(filters: CatalogFilters = {}): Promise<CatalogCosmetic[]> {
+	async run(filters: CatalogFilters = {}, userId?: string | null): Promise<CatalogCosmetic[]> {
 		const cosmetics = await this.repository.findAll();
+
+		// Resolve access once — O(1) repo fetch regardless of catalog size (RFC §8).
+		const access = await this.gatekeeper.accessFor(userId ?? null);
 
 		const visible = cosmetics.filter(
 			(cosmetic) =>
 				cosmetic.active &&
+				access.canUse(cosmetic) &&
 				(filters.type === undefined || cosmetic.type === filters.type) &&
 				(filters.tier === undefined || cosmetic.tier === filters.tier),
 		);

--- a/src/modules/entitlements/application/EntitlementsGatekeeper.ts
+++ b/src/modules/entitlements/application/EntitlementsGatekeeper.ts
@@ -1,35 +1,43 @@
 import { CosmeticTier } from "../../catalog/domain/CosmeticTier";
-import { tierGrants } from "../domain/accessTier";
+import { CosmeticAccess } from "../domain/CosmeticAccess";
 import { EntitlementRepository } from "../domain/EntitlementRepository";
 import { GrantType } from "../domain/GrantType";
 
 // The single access gate for cosmetics. Every access check must pass through here
-// — callers never compare tiers themselves (RFC §8). Today it resolves an ordinal
-// tier; new access sources (purchases, donation ranks) plug in here without
-// changing any caller.
+// — callers never compare tiers themselves (RFC §8). Resolves one snapshot
+// (CosmeticAccess) per user/request so N cosmetics cost O(1) repo fetches.
 export class EntitlementsGatekeeper {
 	constructor(private readonly entitlements: EntitlementRepository) {}
 
-	async canUse(
-		userId: string,
-		cosmetic: { tier: CosmeticTier },
-		at: Date = new Date(),
-	): Promise<boolean> {
-		const userTier = await this.deriveTier(userId, at);
-		return tierGrants(userTier, cosmetic.tier);
-	}
+	async accessFor(userId: string | null, at: Date = new Date()): Promise<CosmeticAccess> {
+		if (userId === null) {
+			return new CosmeticAccess(CosmeticTier.STANDARD, new Set());
+		}
 
-	private async deriveTier(userId: string, at: Date): Promise<CosmeticTier> {
 		const granted = await this.entitlements.findByUserId(userId);
 
 		const isDonor = granted.some(
-			(entitlement) =>
-				entitlement.grantType === GrantType.TIER &&
-				entitlement.grantValue === CosmeticTier.DONOR &&
-				entitlement.isActiveAt(at),
+			(e) =>
+				e.grantType === GrantType.TIER &&
+				e.grantValue === CosmeticTier.DONOR &&
+				e.isActiveAt(at),
 		);
 
-		// Authenticated users are registered at minimum; donor when actively granted.
-		return isDonor ? CosmeticTier.DONOR : CosmeticTier.REGISTERED;
+		const cosmeticIds = new Set(
+			granted
+				.filter((e) => e.grantType === GrantType.COSMETIC && e.isActiveAt(at))
+				.map((e) => e.grantValue),
+		);
+
+		const tier = isDonor ? CosmeticTier.DONOR : CosmeticTier.REGISTERED;
+		return new CosmeticAccess(tier, cosmeticIds);
+	}
+
+	async canUse(
+		userId: string,
+		cosmetic: { id: string; tier: CosmeticTier },
+		at: Date = new Date(),
+	): Promise<boolean> {
+		return (await this.accessFor(userId, at)).canUse(cosmetic);
 	}
 }

--- a/src/modules/entitlements/domain/CosmeticAccess.ts
+++ b/src/modules/entitlements/domain/CosmeticAccess.ts
@@ -1,0 +1,15 @@
+import { CosmeticTier } from "../../catalog/domain/CosmeticTier";
+import { tierGrants } from "./accessTier";
+
+// Resolved access snapshot for a single user/request. Built once by the gatekeeper
+// (one repo fetch) and evaluated synchronously per cosmetic — avoids N+1 queries.
+export class CosmeticAccess {
+	constructor(
+		private readonly tier: CosmeticTier,
+		private readonly cosmeticIds: ReadonlySet<string>,
+	) {}
+
+	canUse(c: { id: string; tier: CosmeticTier }): boolean {
+		return tierGrants(this.tier, c.tier) || this.cosmeticIds.has(c.id);
+	}
+}

--- a/src/server/routes/cosmetics-router.ts
+++ b/src/server/routes/cosmetics-router.ts
@@ -5,15 +5,20 @@ import { GetCosmeticsCatalog } from "../../modules/catalog/application/GetCosmet
 import { CosmeticTier } from "../../modules/catalog/domain/CosmeticTier";
 import { CosmeticType } from "../../modules/catalog/domain/CosmeticType";
 import { CosmeticPostgresRepository } from "../../modules/catalog/infrastructure/CosmeticPostgresRepository";
+import { EntitlementsGatekeeper } from "../../modules/entitlements/application/EntitlementsGatekeeper";
+import { EntitlementPostgresRepository } from "../../modules/entitlements/infrastructure/EntitlementPostgresRepository";
+
+const gatekeeper = new EntitlementsGatekeeper(new EntitlementPostgresRepository());
 
 const getCosmeticsCatalog = new GetCosmeticsCatalog(
 	new CosmeticPostgresRepository(),
 	createR2AssetUrlSigner(),
+	gatekeeper,
 );
 
 export const cosmeticsRouter = new Elysia({ prefix: "/cosmetics" }).get(
 	"/",
-	({ query }) => getCosmeticsCatalog.run({ type: query.type, tier: query.tier }),
+	({ query }) => getCosmeticsCatalog.run({ type: query.type, tier: query.tier }, null),
 	{
 		query: t.Object({
 			type: t.Optional(t.Enum(CosmeticType)),
@@ -23,7 +28,7 @@ export const cosmeticsRouter = new Elysia({ prefix: "/cosmetics" }).get(
 			tags: ["Cosmetics"],
 			summary: "List the cosmetics catalog",
 			description:
-				"Public catalog of cosmetics, filterable by type and tier. Each item includes a manifest of short-lived signed URLs, one per asset file under the cosmetic's storage prefix.",
+				"Public catalog of cosmetics (STANDARD tier only). Filterable by type and tier. Each item includes a manifest of short-lived signed URLs, one per asset file under the cosmetic's storage prefix.",
 		},
 	},
 );

--- a/src/server/routes/me-cosmetics-router.ts
+++ b/src/server/routes/me-cosmetics-router.ts
@@ -1,0 +1,44 @@
+import { bearer } from "@elysiajs/bearer";
+import { Elysia, t } from "elysia";
+
+import { config } from "../../config";
+import { createR2AssetUrlSigner } from "../../modules/assets/infrastructure/createR2AssetUrlSigner";
+import { GetCosmeticsCatalog } from "../../modules/catalog/application/GetCosmeticsCatalog";
+import { CosmeticTier } from "../../modules/catalog/domain/CosmeticTier";
+import { CosmeticType } from "../../modules/catalog/domain/CosmeticType";
+import { CosmeticPostgresRepository } from "../../modules/catalog/infrastructure/CosmeticPostgresRepository";
+import { EntitlementsGatekeeper } from "../../modules/entitlements/application/EntitlementsGatekeeper";
+import { EntitlementPostgresRepository } from "../../modules/entitlements/infrastructure/EntitlementPostgresRepository";
+import { JWT } from "../../shared/JWT";
+
+const jwt = new JWT(config.jwt);
+const gatekeeper = new EntitlementsGatekeeper(new EntitlementPostgresRepository());
+
+const getCosmeticsCatalog = new GetCosmeticsCatalog(
+	new CosmeticPostgresRepository(),
+	createR2AssetUrlSigner(),
+	gatekeeper,
+);
+
+export const meCosmeticsRouter = new Elysia({ prefix: "/me/cosmetics" })
+	.use(bearer())
+	.get(
+		"/",
+		({ bearer, query }) => {
+			const { id } = jwt.decode(bearer as string) as { id: string };
+			return getCosmeticsCatalog.run({ type: query.type, tier: query.tier }, id);
+		},
+		{
+			query: t.Object({
+				type: t.Optional(t.Enum(CosmeticType)),
+				tier: t.Optional(t.Enum(CosmeticTier)),
+			}),
+			detail: {
+				tags: ["Cosmetics"],
+				summary: "List my cosmetics catalog",
+				description:
+					"Personalized catalog of cosmetics visible to the authenticated user. Includes cosmetics covered by the user's tier or individual COSMETIC grants. Each item includes a manifest of short-lived signed URLs.",
+				security: [{ bearerAuth: [] }],
+			},
+		},
+	);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -13,6 +13,7 @@ import { banListRouter } from "./routes/ban-list-router";
 import { cosmeticsRouter } from "./routes/cosmetics-router";
 import { leaderboardRouter } from "./routes/leaderboard-router";
 import { loadoutRouter } from "./routes/loadout-router";
+import { meCosmeticsRouter } from "./routes/me-cosmetics-router";
 import { publicLoadoutRouter } from "./routes/public-loadout-router";
 import { statsRouter } from "./routes/stats-router";
 import { ticketRouter } from "./routes/ticket-router";
@@ -130,6 +131,7 @@ export class Server {
 				.use(wrappedRouter)
 				.use(ticketRouter)
 				.use(cosmeticsRouter)
+				.use(meCosmeticsRouter)
 				.use(loadoutRouter)
 				.use(publicLoadoutRouter)
 

--- a/tests/unit/modules/catalog/application/GetCosmeticsCatalog.test.ts
+++ b/tests/unit/modules/catalog/application/GetCosmeticsCatalog.test.ts
@@ -6,6 +6,12 @@ import { CosmeticRepository } from "../../../../../src/modules/catalog/domain/Co
 import { CosmeticTier } from "../../../../../src/modules/catalog/domain/CosmeticTier";
 import { CosmeticType } from "../../../../../src/modules/catalog/domain/CosmeticType";
 import { AssetUrlSigner } from "../../../../../src/modules/assets/domain/AssetUrlSigner";
+import { CosmeticAccess } from "../../../../../src/modules/entitlements/domain/CosmeticAccess";
+import { EntitlementsGatekeeper } from "../../../../../src/modules/entitlements/application/EntitlementsGatekeeper";
+import { EntitlementRepository } from "../../../../../src/modules/entitlements/domain/EntitlementRepository";
+import { Entitlement } from "../../../../../src/modules/entitlements/domain/Entitlement";
+import { GrantType } from "../../../../../src/modules/entitlements/domain/GrantType";
+import { EntitlementSource } from "../../../../../src/modules/entitlements/domain/EntitlementSource";
 
 const sleeve = Cosmetic.from({
 	id: "1",
@@ -31,48 +37,205 @@ const inactive = Cosmetic.from({
 	displayName: "C",
 	active: false,
 });
+const donorMat = Cosmetic.from({
+	id: "mat-exclusive",
+	type: CosmeticType.PLAYMAT,
+	tier: CosmeticTier.DONOR,
+	assetRef: "playmats/exclusive/",
+	displayName: "Exclusive",
+	active: true,
+});
+const otherDonorMat = Cosmetic.from({
+	id: "other-donor",
+	type: CosmeticType.PLAYMAT,
+	tier: CosmeticTier.DONOR,
+	assetRef: "playmats/other/",
+	displayName: "Other Donor",
+	active: true,
+});
+const retiredSleeve = Cosmetic.from({
+	id: "retired-sleeve",
+	type: CosmeticType.SLEEVE,
+	tier: CosmeticTier.DONOR,
+	assetRef: "sleeves/retired/",
+	displayName: "Retired",
+	active: false,
+});
 
-function catalogOf(cosmetics: Cosmetic[]): GetCosmeticsCatalog {
-	const repository: CosmeticRepository = {
+const signer: AssetUrlSigner = {
+	sign: () => "",
+	signMany: () => ({}),
+	signManifest: async (prefix) => ({ "render.jpg": `signed:${prefix}render.jpg` }),
+};
+
+function fakeRepo(cosmetics: Cosmetic[]): CosmeticRepository {
+	return {
 		findAll: async () => cosmetics,
 		findById: async () => null,
 		save: async () => undefined,
 	};
-	const signer: AssetUrlSigner = {
-		sign: () => "",
-		signMany: () => ({}),
-		signManifest: async (prefix) => ({ "render.jpg": `signed:${prefix}render.jpg` }),
-	};
+}
 
-	return new GetCosmeticsCatalog(repository, signer);
+function gatekeeperWith(entitlements: Entitlement[]): { gk: EntitlementsGatekeeper; callCount: () => number } {
+	let calls = 0;
+	const repo: EntitlementRepository = {
+		findByUserId: async () => { calls++; return entitlements; },
+		save: async () => undefined,
+	};
+	return { gk: new EntitlementsGatekeeper(repo), callCount: () => calls };
+}
+
+function makeCatalog(cosmetics: Cosmetic[], gk: EntitlementsGatekeeper): GetCosmeticsCatalog {
+	return new GetCosmeticsCatalog(fakeRepo(cosmetics), signer, gk);
+}
+
+// Legacy helper for old tests (no userId → no gatekeeper needed — but after the
+// refactor, catalog requires a gatekeeper; we inject a real one backed by an
+// empty repo so anon users see STANDARD access, which matches the prior behaviour
+// for the two old tests that only have STANDARD/REGISTERED cosmetics and called
+// run() with no userId).
+function catalogOf(cosmetics: Cosmetic[]): GetCosmeticsCatalog {
+	const { gk } = gatekeeperWith([]);
+	return makeCatalog(cosmetics, gk);
 }
 
 describe("GetCosmeticsCatalog", () => {
-	it("returns active cosmetics with their signed asset manifest", async () => {
-		const result = await catalogOf([sleeve, playmat]).run();
+	// --- original tests (now run with null userId — anon path) ---
+
+	it("returns active cosmetics with their signed asset manifest (anon, STANDARD+REGISTERED here passes since they both fit)", async () => {
+		// sleeve=STANDARD, playmat=REGISTERED. Anon user gets STANDARD only.
+		// Updating expectation: registered access no longer assumed for anon.
+		// Use a registered gatekeeper to preserve the original test intent.
+		const { gk } = gatekeeperWith([]);
+		const catalog = new GetCosmeticsCatalog(fakeRepo([sleeve, playmat]), signer, gk);
+		// Run with registeredUserId so both are visible (mirroring original behaviour)
+		const result = await catalog.run({}, "registered-user");
 
 		expect(result).toHaveLength(2);
 		expect(result[0].assets).toEqual({ "render.jpg": "signed:sleeves/a/render.jpg" });
 	});
 
 	it("excludes inactive cosmetics", async () => {
-		const result = await catalogOf([sleeve, inactive]).run();
+		const result = await catalogOf([sleeve, inactive]).run({}, null);
 
 		expect(result).toHaveLength(1);
 		expect(result[0].id).toBe("1");
 	});
 
 	it("filters by type", async () => {
-		const result = await catalogOf([sleeve, playmat]).run({ type: CosmeticType.PLAYMAT });
+		const { gk } = gatekeeperWith([]);
+		const catalog = makeCatalog([sleeve, playmat], gk);
+		const result = await catalog.run({ type: CosmeticType.PLAYMAT }, "registered-user");
 
 		expect(result).toHaveLength(1);
 		expect(result[0].type).toBe(CosmeticType.PLAYMAT);
 	});
 
 	it("filters by tier", async () => {
-		const result = await catalogOf([sleeve, playmat]).run({ tier: CosmeticTier.STANDARD });
+		const { gk } = gatekeeperWith([]);
+		const catalog = makeCatalog([sleeve, playmat], gk);
+		const result = await catalog.run({ tier: CosmeticTier.STANDARD }, "registered-user");
 
 		expect(result).toHaveLength(1);
 		expect(result[0].tier).toBe(CosmeticTier.STANDARD);
+	});
+
+	// --- new personalized catalog tests ---
+
+	it("anonymous user sees only STANDARD cosmetics", async () => {
+		const { gk } = gatekeeperWith([]);
+		const catalog = makeCatalog([sleeve, playmat, donorMat], gk);
+
+		const result = await catalog.run({}, null);
+
+		expect(result.every((c) => c.tier === CosmeticTier.STANDARD)).toBe(true);
+		expect(result).toHaveLength(1);
+	});
+
+	it("registered user sees STANDARD and REGISTERED, not DONOR", async () => {
+		const { gk } = gatekeeperWith([]);
+		const catalog = makeCatalog([sleeve, playmat, donorMat], gk);
+
+		const result = await catalog.run({}, "user-registered");
+
+		const tiers = result.map((c) => c.tier);
+		expect(tiers).toContain(CosmeticTier.STANDARD);
+		expect(tiers).toContain(CosmeticTier.REGISTERED);
+		expect(tiers).not.toContain(CosmeticTier.DONOR);
+	});
+
+	it("donor user sees all three tiers", async () => {
+		const donorTierGrant = Entitlement.create({
+			id: "e-donor",
+			userId: "user-donor",
+			grantType: GrantType.TIER,
+			grantValue: CosmeticTier.DONOR,
+			source: EntitlementSource.DONATION,
+			expiresAt: null,
+		});
+		const { gk } = gatekeeperWith([donorTierGrant]);
+		const catalog = makeCatalog([sleeve, playmat, donorMat], gk);
+
+		const result = await catalog.run({}, "user-donor");
+
+		const tiers = result.map((c) => c.tier);
+		expect(tiers).toContain(CosmeticTier.STANDARD);
+		expect(tiers).toContain(CosmeticTier.REGISTERED);
+		expect(tiers).toContain(CosmeticTier.DONOR);
+	});
+
+	it("registered user with a COSMETIC grant sees that specific DONOR cosmetic", async () => {
+		const cosmeticGrant = Entitlement.create({
+			id: "e-cosmetic",
+			userId: "user-registered",
+			grantType: GrantType.COSMETIC,
+			grantValue: "mat-exclusive",
+			source: EntitlementSource.PURCHASE,
+			expiresAt: null,
+		});
+		const { gk } = gatekeeperWith([cosmeticGrant]);
+		const catalog = makeCatalog([sleeve, donorMat, otherDonorMat], gk);
+
+		const result = await catalog.run({}, "user-registered");
+
+		const ids = result.map((c) => c.id);
+		expect(ids).toContain("mat-exclusive");
+		expect(ids).not.toContain("other-donor");
+	});
+
+	it("inactive cosmetic is excluded even when user holds a COSMETIC grant for it", async () => {
+		const cosmeticGrant = Entitlement.create({
+			id: "e-cosmetic",
+			userId: "user-1",
+			grantType: GrantType.COSMETIC,
+			grantValue: "retired-sleeve",
+			source: EntitlementSource.PURCHASE,
+			expiresAt: null,
+		});
+		const { gk } = gatekeeperWith([cosmeticGrant]);
+		const catalog = makeCatalog([sleeve, retiredSleeve], gk);
+
+		const result = await catalog.run({}, "user-1");
+
+		expect(result.map((c) => c.id)).not.toContain("retired-sleeve");
+	});
+
+	it("N+1 guard: only one accessFor call regardless of cosmetic count", async () => {
+		// Use a spy gatekeeper to count accessFor calls.
+		let accessForCalls = 0;
+		const spyGk = {
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			accessFor: async (_userId: string | null) => {
+				accessForCalls++;
+				return new CosmeticAccess(CosmeticTier.REGISTERED, new Set());
+			},
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			canUse: async (_userId: string, _c: { id: string; tier: CosmeticTier }) => false,
+		} as unknown as EntitlementsGatekeeper;
+
+		const catalog = makeCatalog([sleeve, playmat, donorMat, otherDonorMat], spyGk);
+		await catalog.run({}, "user-1");
+
+		expect(accessForCalls).toBe(1);
 	});
 });

--- a/tests/unit/modules/entitlements/application/EntitlementsGatekeeper.test.ts
+++ b/tests/unit/modules/entitlements/application/EntitlementsGatekeeper.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { CosmeticTier } from "../../../../../src/modules/catalog/domain/CosmeticTier";
+import { CosmeticAccess } from "../../../../../src/modules/entitlements/domain/CosmeticAccess";
 import { Entitlement } from "../../../../../src/modules/entitlements/domain/Entitlement";
 import { EntitlementRepository } from "../../../../../src/modules/entitlements/domain/EntitlementRepository";
 import { EntitlementSource } from "../../../../../src/modules/entitlements/domain/EntitlementSource";
@@ -9,13 +10,17 @@ import { EntitlementsGatekeeper } from "../../../../../src/modules/entitlements/
 
 const NOW = new Date("2026-06-08T00:00:00Z");
 
-function gatekeeper(entitlements: Entitlement[]): EntitlementsGatekeeper {
-	const repository: EntitlementRepository = {
-		findByUserId: async () => entitlements,
+function makeRepo(entitlements: Entitlement[]): { repo: EntitlementRepository; callCount: () => number } {
+	let calls = 0;
+	const repo: EntitlementRepository = {
+		findByUserId: async () => { calls++; return entitlements; },
 		save: async () => undefined,
 	};
+	return { repo, callCount: () => calls };
+}
 
-	return new EntitlementsGatekeeper(repository);
+function gatekeeper(entitlements: Entitlement[]): EntitlementsGatekeeper {
+	return new EntitlementsGatekeeper(makeRepo(entitlements).repo);
 }
 
 function donorGrant(expiresAt: Date | null): Entitlement {
@@ -29,24 +34,91 @@ function donorGrant(expiresAt: Date | null): Entitlement {
 	});
 }
 
+function cosmeticGrant(cosmeticId: string, expiresAt: Date | null): Entitlement {
+	return Entitlement.create({
+		id: "e2",
+		userId: "user-1",
+		grantType: GrantType.COSMETIC,
+		grantValue: cosmeticId,
+		source: EntitlementSource.PURCHASE,
+		expiresAt,
+	});
+}
+
 describe("EntitlementsGatekeeper", () => {
+	// --- existing tier-based tests (regression) ---
+
 	it("lets a registered user (no donor grant) use standard and registered cosmetics, but not donor", async () => {
 		const gk = gatekeeper([]);
 
-		expect(await gk.canUse("user-1", { tier: CosmeticTier.STANDARD }, NOW)).toBe(true);
-		expect(await gk.canUse("user-1", { tier: CosmeticTier.REGISTERED }, NOW)).toBe(true);
-		expect(await gk.canUse("user-1", { tier: CosmeticTier.DONOR }, NOW)).toBe(false);
+		expect(await gk.canUse("user-1", { id: "s1", tier: CosmeticTier.STANDARD }, NOW)).toBe(true);
+		expect(await gk.canUse("user-1", { id: "r1", tier: CosmeticTier.REGISTERED }, NOW)).toBe(true);
+		expect(await gk.canUse("user-1", { id: "d1", tier: CosmeticTier.DONOR }, NOW)).toBe(false);
 	});
 
 	it("lets a user with an active donor grant use donor cosmetics", async () => {
 		const gk = gatekeeper([donorGrant(null)]);
 
-		expect(await gk.canUse("user-1", { tier: CosmeticTier.DONOR }, NOW)).toBe(true);
+		expect(await gk.canUse("user-1", { id: "d1", tier: CosmeticTier.DONOR }, NOW)).toBe(true);
 	});
 
 	it("ignores an expired donor grant", async () => {
 		const gk = gatekeeper([donorGrant(new Date("2026-01-01T00:00:00Z"))]);
 
-		expect(await gk.canUse("user-1", { tier: CosmeticTier.DONOR }, NOW)).toBe(false);
+		expect(await gk.canUse("user-1", { id: "d1", tier: CosmeticTier.DONOR }, NOW)).toBe(false);
+	});
+
+	// --- new accessFor tests ---
+
+	it("accessFor returns CosmeticAccess instance", async () => {
+		const gk = gatekeeper([]);
+		const access = await gk.accessFor("user-1", NOW);
+
+		expect(access).toBeInstanceOf(CosmeticAccess);
+	});
+
+	it("accessFor: active COSMETIC grant for matching id grants the cosmetic above ordinal tier", async () => {
+		const gk = gatekeeper([cosmeticGrant("mat-exclusive", null)]);
+		const access = await gk.accessFor("user-1", NOW);
+
+		expect(access.canUse({ id: "mat-exclusive", tier: CosmeticTier.DONOR })).toBe(true);
+	});
+
+	it("accessFor: active COSMETIC grant for a different id does not grant the cosmetic", async () => {
+		const gk = gatekeeper([cosmeticGrant("mat-exclusive", null)]);
+		const access = await gk.accessFor("user-1", NOW);
+
+		expect(access.canUse({ id: "other-donor", tier: CosmeticTier.DONOR })).toBe(false);
+	});
+
+	it("accessFor: expired COSMETIC grant is ignored", async () => {
+		const gk = gatekeeper([cosmeticGrant("mat-exclusive", new Date("2026-01-01T00:00:00Z"))]);
+		const access = await gk.accessFor("user-1", NOW);
+
+		expect(access.canUse({ id: "mat-exclusive", tier: CosmeticTier.DONOR })).toBe(false);
+	});
+
+	it("accessFor(null) returns STANDARD access without calling the repository", async () => {
+		const { repo, callCount } = makeRepo([]);
+		const gk = new EntitlementsGatekeeper(repo);
+		const access = await gk.accessFor(null, NOW);
+
+		expect(access.canUse({ id: "s1", tier: CosmeticTier.STANDARD })).toBe(true);
+		expect(access.canUse({ id: "r1", tier: CosmeticTier.REGISTERED })).toBe(false);
+		expect(access.canUse({ id: "d1", tier: CosmeticTier.DONOR })).toBe(false);
+		expect(callCount()).toBe(0);
+	});
+
+	it("N+1 guard: accessFor calls findByUserId exactly once regardless of how many canUse calls follow", async () => {
+		const { repo, callCount } = makeRepo([]);
+		const gk = new EntitlementsGatekeeper(repo);
+		const access = await gk.accessFor("user-1", NOW);
+
+		// Multiple canUse calls — all synchronous, no extra fetches.
+		access.canUse({ id: "s1", tier: CosmeticTier.STANDARD });
+		access.canUse({ id: "r1", tier: CosmeticTier.REGISTERED });
+		access.canUse({ id: "d1", tier: CosmeticTier.DONOR });
+
+		expect(callCount()).toBe(1);
 	});
 });

--- a/tests/unit/modules/entitlements/domain/CosmeticAccess.test.ts
+++ b/tests/unit/modules/entitlements/domain/CosmeticAccess.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+
+import { CosmeticAccess } from "../../../../../src/modules/entitlements/domain/CosmeticAccess";
+import { CosmeticTier } from "../../../../../src/modules/catalog/domain/CosmeticTier";
+
+describe("CosmeticAccess", () => {
+	it("grants access when ordinal tier covers the cosmetic's tier", () => {
+		const access = new CosmeticAccess(CosmeticTier.REGISTERED, new Set());
+
+		expect(access.canUse({ id: "mat-1", tier: CosmeticTier.STANDARD })).toBe(true);
+		expect(access.canUse({ id: "mat-1", tier: CosmeticTier.REGISTERED })).toBe(true);
+	});
+
+	it("denies access when ordinal tier is insufficient and id is not in the granted set", () => {
+		const access = new CosmeticAccess(CosmeticTier.REGISTERED, new Set());
+
+		expect(access.canUse({ id: "mat-donor", tier: CosmeticTier.DONOR })).toBe(false);
+	});
+
+	it("grants access by cosmetic id even when tier is insufficient", () => {
+		const access = new CosmeticAccess(CosmeticTier.REGISTERED, new Set(["mat-exclusive"]));
+
+		expect(access.canUse({ id: "mat-exclusive", tier: CosmeticTier.DONOR })).toBe(true);
+	});
+
+	it("denies access when id does not match and tier is insufficient", () => {
+		const access = new CosmeticAccess(CosmeticTier.REGISTERED, new Set(["mat-exclusive"]));
+
+		expect(access.canUse({ id: "other-donor", tier: CosmeticTier.DONOR })).toBe(false);
+	});
+
+	it("STANDARD access grants only STANDARD cosmetics", () => {
+		const access = new CosmeticAccess(CosmeticTier.STANDARD, new Set());
+
+		expect(access.canUse({ id: "s1", tier: CosmeticTier.STANDARD })).toBe(true);
+		expect(access.canUse({ id: "r1", tier: CosmeticTier.REGISTERED })).toBe(false);
+		expect(access.canUse({ id: "d1", tier: CosmeticTier.DONOR })).toBe(false);
+	});
+});

--- a/tests/unit/modules/loadout/application/EquipCosmetic.test.ts
+++ b/tests/unit/modules/loadout/application/EquipCosmetic.test.ts
@@ -6,6 +6,8 @@ import { CosmeticTier } from "../../../../../src/modules/catalog/domain/Cosmetic
 import { CosmeticType } from "../../../../../src/modules/catalog/domain/CosmeticType";
 import { EntitlementsGatekeeper } from "../../../../../src/modules/entitlements/application/EntitlementsGatekeeper";
 import { Entitlement } from "../../../../../src/modules/entitlements/domain/Entitlement";
+import { EntitlementSource } from "../../../../../src/modules/entitlements/domain/EntitlementSource";
+import { GrantType } from "../../../../../src/modules/entitlements/domain/GrantType";
 import { EquipCosmetic } from "../../../../../src/modules/loadout/application/EquipCosmetic";
 import { Loadout } from "../../../../../src/modules/loadout/domain/Loadout";
 import { LoadoutRepository } from "../../../../../src/modules/loadout/domain/LoadoutRepository";
@@ -81,5 +83,24 @@ describe("EquipCosmetic", () => {
 		await expect(
 			equip.run({ userId: "user-1", cosmeticType: CosmeticType.PLAYMAT, cosmeticId: "cosmetic-1" }),
 		).rejects.toBeInstanceOf(InvalidArgumentError);
+	});
+
+	// --- COSMETIC grant regression (spec: catalog scenario 6) ---
+
+	it("allows equipping a DONOR cosmetic when user holds a COSMETIC grant for it", async () => {
+		const cosmeticGrant = Entitlement.create({
+			id: "e-grant",
+			userId: "user-1",
+			grantType: GrantType.COSMETIC,
+			grantValue: "cosmetic-1",
+			source: EntitlementSource.PURCHASE,
+			expiresAt: null,
+		});
+		const { equip, saved } = build({ found: cosmetic(CosmeticTier.DONOR), entitlements: [cosmeticGrant] });
+
+		await equip.run({ userId: "user-1", cosmeticType: CosmeticType.SLEEVE, cosmeticId: "cosmetic-1" });
+
+		expect(saved).toHaveLength(1);
+		expect(saved[0].equippedCosmeticId(CosmeticType.SLEEVE)).toBe("cosmetic-1");
 	});
 });

--- a/tests/unit/server/routes/me-cosmetics-router.test.ts
+++ b/tests/unit/server/routes/me-cosmetics-router.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { Elysia } from "elysia";
+
+import { meCosmeticsRouter } from "../../../../src/server/routes/me-cosmetics-router";
+import { AuthenticationError } from "../../../../src/shared/errors/AuthenticationError";
+
+// Transport-level auth contract for GET /me/cosmetics. The 401 mapping for
+// AuthenticationError lives in Server.onError (not in the router), so the test
+// mounts the router under an Elysia app that mirrors that single mapping — the
+// same shape server.ts wires in production. This proves an unauthenticated
+// request is rejected, so no personalized catalog ever leaks on this route.
+const app = new Elysia()
+	.onError(({ error, set }) => {
+		if (error instanceof AuthenticationError) set.status = 401;
+	})
+	.use(meCosmeticsRouter);
+
+describe("GET /me/cosmetics — transport auth", () => {
+	it("responds 401 when no bearer token is provided", async () => {
+		const response = await app.handle(new Request("http://localhost/me/cosmetics"));
+
+		expect(response.status).toBe(401);
+	});
+
+	it("responds 401 when the bearer token is invalid", async () => {
+		const response = await app.handle(
+			new Request("http://localhost/me/cosmetics", {
+				headers: { Authorization: "Bearer not-a-valid-jwt" },
+			}),
+		);
+
+		expect(response.status).toBe(401);
+	});
+});


### PR DESCRIPTION
## Summary
- Cosmetic **visibility = usability**: the catalog now returns only what a user can use, decided in the backend through the single access gate (RFC §8).
- `EntitlementsGatekeeper` now honors per-asset `COSMETIC` grants (earned assets), not just the ordinal tier, and resolves access **once per request** (no N+1).
- New authenticated `GET /api/v1/me/cosmetics` serves the personalized catalog; public `GET /cosmetics` now resolves anonymous → STANDARD.

## Changes
| File | Change |
|------|--------|
| `entitlements/domain/CosmeticAccess.ts` | NEW — value object: resolved tier + granted cosmeticIds; pure `canUse` (tier OR grant) |
| `entitlements/application/EntitlementsGatekeeper.ts` | `accessFor(userId\|null)` (one fetch), `canUse` delegates, anonymous→STANDARD, cosmetic param widened to `{id,tier}` |
| `catalog/application/GetCosmeticsCatalog.ts` | personalized: `run(filters, userId?)` filters via `access.canUse` |
| `server/routes/cosmetics-router.ts` | public route passes `userId: null` (anon→STANDARD) |
| `server/routes/me-cosmetics-router.ts` | NEW — authed `/me/cosmetics`, bearer + JWT (mirrors `loadout-router`) |
| `server/server.ts` | mount `meCosmeticsRouter` under `/api/v1` |
| `tests/**` | unit tests for the above + EquipCosmetic regression + transport 401 test |

## Test plan
- [x] `bun test` → **170 pass / 0 fail**
- [x] `bun run lint` → 0 errors
- [x] 12 spec scenarios covered (tier / COSMETIC / expired grant, anon = STANDARD, catalog per tier, equip regression)
- [x] Transport: `GET /me/cosmetics` → 401 with no bearer and with invalid bearer

## ⚠️ Rollout — read before merging
**Do NOT merge to production before frontend Slice 2** (the client sending its bearer to `/me/cosmetics`). The front today calls public `/cosmetics` without a token, so on its own this change makes the logged-in catalog show STANDARD-only.

## Notes
- **Size:** ~500 changed lines, but ~390 are tests (4 new test files under strict TDD). Work units are tightly sequential, so chained PRs would add interface-stub overhead with little benefit — accepted as a single PR (`size:exception` rationale; repo has no size label).
- **No schema/migration** — the `entitlements` / `cosmetics` schema already supports TIER/COSMETIC grants, sources and expiry.
- **Follow-ups:** Slice 2 (front: send bearer + refetch on login/logout); Slice 3 (use case to grant a COSMETIC entitlement + revalidate loadout on lost access).
- No issue linked — this repo has no issue-gate workflow.
