### PR TITLE
feat(cosmetics): gate premium sleeves to REGISTERED and add Evolution covers

### DIFF
--- a/src/migrations/1781016036903-set_sleeve_tiers.ts
+++ b/src/migrations/1781016036903-set_sleeve_tiers.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+// Promote the three premium sleeves (baby-frog, kagura, mystical-witch) to
+// REGISTERED so anonymous players no longer see or equip them — they now require
+// an account. These rows were already seeded as STANDARD; the seed only INSERTS
+// missing rows (matched by asset_ref) and never updates an existing tier, so this
+// change MUST be a data migration. The new STANDARD sleeves (evolution,
+// evolution-black) are inserted by the seed, not here.
+export class SetSleeveTiers1781016036903 implements MigrationInterface {
+	name = "SetSleeveTiers1781016036903";
+
+	private readonly refs = [
+		"sleeves/baby-frog/",
+		"sleeves/kagura/",
+		"sleeves/mystical-witch/",
+	];
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`UPDATE "cosmetics" SET "tier" = 'REGISTERED', "updated_at" = now() WHERE "asset_ref" = ANY($1)`,
+			[this.refs],
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`UPDATE "cosmetics" SET "tier" = 'STANDARD', "updated_at" = now() WHERE "asset_ref" = ANY($1)`,
+			[this.refs],
+		);
+	}
+}

--- a/src/modules/catalog/application/standardCosmetics.ts
+++ b/src/modules/catalog/application/standardCosmetics.ts
@@ -8,14 +8,20 @@ export interface StandardCosmeticSeed {
 	displayName: string;
 }
 
-// The standard set every player gets. asset_ref is the R2 folder prefix; the
+// The cosmetic set seeded on bootstrap. asset_ref is the R2 folder prefix; the
 // individual files (render/preview for sleeves, gltf/bin/texture for playmats)
-// live under it and are resolved at serve time.
+// live under it and are resolved at serve time. `tier` gates visibility/usage:
+// anonymous players see STANDARD only; REGISTERED requires an account. NOTE: the
+// seed only INSERTS missing rows (matched by asset_ref) — it never updates the
+// tier of an already-seeded cosmetic, so changing an existing tier needs a
+// data migration (see SetSleeveTiers).
 export const STANDARD_COSMETICS: StandardCosmeticSeed[] = [
-	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.STANDARD, assetRef: "sleeves/baby-frog/", displayName: "Baby Frog" },
+	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.REGISTERED, assetRef: "sleeves/baby-frog/", displayName: "Baby Frog" },
 	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.STANDARD, assetRef: "sleeves/classic/", displayName: "Classic" },
-	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.STANDARD, assetRef: "sleeves/kagura/", displayName: "Kagura" },
-	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.STANDARD, assetRef: "sleeves/mystical-witch/", displayName: "Mystical Witch" },
+	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.REGISTERED, assetRef: "sleeves/kagura/", displayName: "Kagura" },
+	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.REGISTERED, assetRef: "sleeves/mystical-witch/", displayName: "Mystical Witch" },
+	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.STANDARD, assetRef: "sleeves/evolution/", displayName: "Evolution" },
+	{ type: CosmeticType.SLEEVE, tier: CosmeticTier.STANDARD, assetRef: "sleeves/evolution-black/", displayName: "Evolution Black" },
 	{ type: CosmeticType.PLAYMAT, tier: CosmeticTier.STANDARD, assetRef: "playmats/pallet-covered-a/", displayName: "Pallet Covered A" },
 	{ type: CosmeticType.PLAYMAT, tier: CosmeticTier.STANDARD, assetRef: "playmats/pallet-covered-b/", displayName: "Pallet Covered B" },
 	{ type: CosmeticType.PLAYMAT, tier: CosmeticTier.STANDARD, assetRef: "playmats/pallet-wood/", displayName: "Pallet Wood" },


### PR DESCRIPTION
## Summary
- Gate three premium sleeves to **REGISTERED** so anonymous players no longer see/equip them: `baby-frog`, `kagura`, `mystical-witch`.
- Add two new **STANDARD** card-backs: `evolution` and `evolution-black`.
- `classic` and all playmats stay STANDARD.

## Why two mechanisms
The seed (`standardCosmetics.ts`) is idempotent and only INSERTS missing rows (matched by `asset_ref`) — it never updates the tier of an already-seeded cosmetic. So:
- **New** cosmetics (evolution, evolution-black) → added to the seed.
- **Tier change** of existing cosmetics (the 3 premium sleeves) → a **data migration** (`SetSleeveTiers`), because the seed can't touch them.

## Changes
| File | Change |
|------|--------|
| `catalog/application/standardCosmetics.ts` | +evolution, +evolution-black (STANDARD); baby-frog/kagura/mystical-witch → REGISTERED; comment on the seed's insert-only behavior |
| `migrations/1781016036903-set_sleeve_tiers.ts` | NEW — `UPDATE cosmetics SET tier='REGISTERED'` for the 3 existing premium sleeves; reversible `down` reverts to STANDARD |

## Test plan
- [x] `bun test` → **190 pass / 0 fail**
- [x] `bun run lint` → 0 errors (2 pre-existing warnings in `build/` artifact only)
- [x] Seed test unaffected (uses `STANDARD_COSMETICS.length` dynamically, no hardcoded count/tier asserts)

## ⚠️ Deploy order (matters)
1. **Upload** `sleeves/evolution/` + `sleeves/evolution-black/` (render.jpg + preview.jpg) to the R2 `evolution` bucket — assets are optimized and staged in `inventory-r2-staging/`.
2. `migration:cosmetics:run` → the 3 premium sleeves become REGISTERED (disappear from the anonymous catalog — intended).
3. `seed:cosmetics` → inserts the 2 new EV covers. Run AFTER the upload, or they render with broken (nonexistent) asset URLs.

## Notes
- Effect is now real (post cosmetic-visibility feature): REGISTERED sleeves vanish for anonymous users; the EV covers are visible to everyone (STANDARD).
- No schema change — data-only migration.
