### PR TITLE
fix(auth): harden forgot-password recovery (per-frontend links + anti-enumeration)

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -41,19 +41,11 @@ export const config = {
 		apiUrl: ensureEnvVariable(process.env.TOURNAMENTS_API_URL as string, "TOURNAMENTS_API_URL"),
 		webhookUrl: ensureEnvVariable(process.env.TOURNAMENTS_WEBHOOK_URL as string, "TOURNAMENTS_WEBHOOK_URL"),
 	},
-	// Per-frontend password-recovery links. Each frontend is a different app with its
-	// own routing, so the email link is selected by the request origin (NOT trusted to
-	// build the URL — the URL always comes from here). Add a new frontend by adding an
-	// entry; the client contract never changes.
 	passwordRecovery: {
-		// Used when the request origin matches no known frontend.
 		defaultResetUrl: "https://evolutionygo.com/reset-password?token={token}",
 		frontends: [
-			// evolutionygo.com — existing app in production, preserved exactly as-is.
 			{ origin: "https://evolutionygo.com", template: "https://evolutionygo.com/reset-password?token={token}" },
-			// evoduel.com — new SPA (hash-routed), recovers the strong account password.
 			{ origin: "https://evoduel.com", template: "https://evoduel.com/#/reset-account-password?token={token}" },
-			// Local development (Vite). Never exposed in production.
 			...(isProduction
 				? []
 				: [

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,6 +10,8 @@ function ensureEnvVariable(variable: string, variableName: string): string {
 	return variable;
 }
 
+const isProduction = process.env.NODE_ENV === "production";
+
 export const config = {
 	sendgrid: {
 		apiKey: ensureEnvVariable(process.env.SENDGRID_API_KEY as string, "SENDGRID_API_KEY"),
@@ -38,5 +40,28 @@ export const config = {
 	tournaments: {
 		apiUrl: ensureEnvVariable(process.env.TOURNAMENTS_API_URL as string, "TOURNAMENTS_API_URL"),
 		webhookUrl: ensureEnvVariable(process.env.TOURNAMENTS_WEBHOOK_URL as string, "TOURNAMENTS_WEBHOOK_URL"),
-	}
+	},
+	// Per-frontend password-recovery links. Each frontend is a different app with its
+	// own routing, so the email link is selected by the request origin (NOT trusted to
+	// build the URL — the URL always comes from here). Add a new frontend by adding an
+	// entry; the client contract never changes.
+	passwordRecovery: {
+		// Used when the request origin matches no known frontend.
+		defaultResetUrl: "https://evolutionygo.com/reset-password?token={token}",
+		frontends: [
+			// evolutionygo.com — existing app in production, preserved exactly as-is.
+			{ origin: "https://evolutionygo.com", template: "https://evolutionygo.com/reset-password?token={token}" },
+			// evoduel.com — new SPA (hash-routed), recovers the strong account password.
+			{ origin: "https://evoduel.com", template: "https://evoduel.com/#/reset-account-password?token={token}" },
+			// Local development (Vite). Never exposed in production.
+			...(isProduction
+				? []
+				: [
+						{
+							origin: "http://localhost:5173",
+							template: "http://localhost:5173/#/reset-account-password?token={token}",
+						},
+					]),
+		],
+	},
 };

--- a/src/modules/user/application/UserForgotPassword.ts
+++ b/src/modules/user/application/UserForgotPassword.ts
@@ -2,6 +2,7 @@ import { EmailSender } from "../../../shared/email/domain/EmailSender";
 import { NotFoundError } from "../../../shared/errors/NotFoundError";
 import { JWT } from "../../../shared/JWT";
 import { Logger } from "../../../shared/logger/domain/Logger";
+import { ResetPasswordLinkBuilder } from "../domain/ResetPasswordLinkBuilder";
 import { UserRepository } from "../domain/UserRepository";
 
 export class UserForgotPassword {
@@ -10,10 +11,18 @@ export class UserForgotPassword {
 		private readonly emailSender: EmailSender,
 		private readonly jwt: JWT,
 		private readonly logger: Logger,
-		private readonly baseUrl: string,
+		private readonly resetLinkBuilder: ResetPasswordLinkBuilder,
 	) {}
 
-	async forgotPassword({ email }: { email: string }): Promise<{ message: string }> {
+	async forgotPassword({
+		email,
+		origin,
+		referer,
+	}: {
+		email: string;
+		origin?: string | null;
+		referer?: string | null;
+	}): Promise<{ message: string }> {
 		this.logger.info(`Forgot password for email ${email}`);
 
 		const user = await this.repository.findByEmail(email);
@@ -23,6 +32,7 @@ export class UserForgotPassword {
 		}
 
 		const token = this.jwt.generate({ id: user.id }, { expiresIn: "1h" });
+		const resetLink = this.resetLinkBuilder.build({ origin, referer, token });
 
 		const emailData = {
 			username: user.username,
@@ -31,7 +41,7 @@ export class UserForgotPassword {
 			html: `
 				<p>Hello ${user.username}!</p>
 				<p>You have requested to reset your password. Use the following link to reset your password:</p>
-				<p><strong>${this.baseUrl}/reset-password?token=${token}</strong></p>
+				<p><strong>${resetLink}</strong></p>
 				<p>This link will expire in 1 hour.</p>
 				<p>If you didn't request this, please ignore this email.</p>
 				<p>Regards,</p>
@@ -40,16 +50,18 @@ export class UserForgotPassword {
 			text: `
 				Hello ${user.username}!
 				You have requested to reset your password. Use the following link to reset your password:
-				${this.baseUrl}/reset-password?token=${token}
+				${resetLink}
 				This link will expire in 1 hour.
 			`,
 		};
 
-		this.emailSender.send(user.email, emailData).catch((error: Error) => {
+		try {
+			await this.emailSender.send(user.email, emailData);
+		} catch (error) {
 			this.logger.error(`Error sending email to ${email}`);
-			this.logger.error(error);
+			this.logger.error(error as Error);
 			throw new Error("Error sending email");
-		});
+		}
 
 		return {
 			message: "Email sent successfully",

--- a/src/modules/user/application/UserForgotPassword.ts
+++ b/src/modules/user/application/UserForgotPassword.ts
@@ -1,5 +1,4 @@
 import { EmailSender } from "../../../shared/email/domain/EmailSender";
-import { NotFoundError } from "../../../shared/errors/NotFoundError";
 import { JWT } from "../../../shared/JWT";
 import { Logger } from "../../../shared/logger/domain/Logger";
 import { ResetPasswordLinkBuilder } from "../domain/ResetPasswordLinkBuilder";
@@ -28,7 +27,11 @@ export class UserForgotPassword {
 		const user = await this.repository.findByEmail(email);
 
 		if (!user) {
-			throw new NotFoundError(`User with email ${email} not found`);
+			// Return the same response whether or not the email exists, so this endpoint
+			// cannot be used to enumerate registered accounts.
+			this.logger.info("Forgot password requested for an unregistered email");
+
+			return { message: "Email sent successfully" };
 		}
 
 		const token = this.jwt.generate({ id: user.id }, { expiresIn: "1h" });

--- a/src/modules/user/application/UserForgotPassword.ts
+++ b/src/modules/user/application/UserForgotPassword.ts
@@ -27,8 +27,7 @@ export class UserForgotPassword {
 		const user = await this.repository.findByEmail(email);
 
 		if (!user) {
-			// Return the same response whether or not the email exists, so this endpoint
-			// cannot be used to enumerate registered accounts.
+			// Same response whether or not the email exists, to prevent account enumeration.
 			this.logger.info("Forgot password requested for an unregistered email");
 
 			return { message: "Email sent successfully" };

--- a/src/modules/user/domain/ResetPasswordLinkBuilder.ts
+++ b/src/modules/user/domain/ResetPasswordLinkBuilder.ts
@@ -1,19 +1,10 @@
 export interface FrontendResetEntry {
-	/** Canonical origin (scheme + host[:port]) used to match the request. */
 	origin: string;
-	/** Reset page URL for that frontend. Must contain the `{token}` placeholder. */
 	template: string;
 }
 
-/**
- * Builds the password-recovery link that goes into the email.
- *
- * Each frontend (e.g. evolutionygo.com, evoduel.com) is a different app with its
- * own routing, so the link is picked from a per-origin registry. The request
- * Origin/Referer is used ONLY to SELECT which frontend; the URL itself always
- * comes from the registry (config), never from the raw header — that is what
- * prevents password-reset poisoning (host/origin header injection).
- */
+// The request origin only SELECTS the frontend; the URL always comes from the
+// registry, never from the raw header — this prevents reset-link poisoning.
 export class ResetPasswordLinkBuilder {
 	private readonly entries: FrontendResetEntry[];
 

--- a/src/modules/user/domain/ResetPasswordLinkBuilder.ts
+++ b/src/modules/user/domain/ResetPasswordLinkBuilder.ts
@@ -1,0 +1,54 @@
+export interface FrontendResetEntry {
+	/** Canonical origin (scheme + host[:port]) used to match the request. */
+	origin: string;
+	/** Reset page URL for that frontend. Must contain the `{token}` placeholder. */
+	template: string;
+}
+
+/**
+ * Builds the password-recovery link that goes into the email.
+ *
+ * Each frontend (e.g. evolutionygo.com, evoduel.com) is a different app with its
+ * own routing, so the link is picked from a per-origin registry. The request
+ * Origin/Referer is used ONLY to SELECT which frontend; the URL itself always
+ * comes from the registry (config), never from the raw header — that is what
+ * prevents password-reset poisoning (host/origin header injection).
+ */
+export class ResetPasswordLinkBuilder {
+	private readonly entries: FrontendResetEntry[];
+
+	constructor(
+		entries: FrontendResetEntry[],
+		private readonly defaultTemplate: string,
+	) {
+		this.entries = entries.map((entry) => ({ origin: this.normalize(entry.origin), template: entry.template }));
+	}
+
+	build({ origin, referer, token }: { origin?: string | null; referer?: string | null; token: string }): string {
+		const requestOrigin = this.resolveOrigin(origin, referer);
+		const entry = requestOrigin ? this.entries.find((candidate) => candidate.origin === requestOrigin) : undefined;
+		const template = entry?.template ?? this.defaultTemplate;
+
+		return template.replaceAll("{token}", token);
+	}
+
+	private resolveOrigin(origin?: string | null, referer?: string | null): string | null {
+		if (origin && origin.trim()) {
+			return this.normalize(origin);
+		}
+
+		if (referer && referer.trim()) {
+			try {
+				return this.normalize(new URL(referer).origin);
+			} catch {
+				return null;
+			}
+		}
+
+		return null;
+	}
+
+	private normalize(value: string): string {
+		return value.trim().toLowerCase().replace(/\/+$/, "");
+	}
+}

--- a/src/server/routes/user-router.ts
+++ b/src/server/routes/user-router.ts
@@ -18,6 +18,7 @@ import { UserAccountPasswordUpdater } from "../../modules/user/application/UserA
 import { UserUpgradePassword } from "../../modules/user/application/UserUpgradePassword";
 import { UserTokenValidator } from "../../modules/user/application/UserTokenValidator";
 import { UserUsernameUpdater } from "../../modules/user/application/UserUsernameUpdater";
+import { ResetPasswordLinkBuilder } from "../../modules/user/domain/ResetPasswordLinkBuilder";
 import { UserPostgresRepository } from "../../modules/user/infrastructure/UserPostgresRepository";
 import { ResendEmailSender } from "../../shared/email/infrastructure/ResendEmailSender";
 import { AuthenticationError } from "../../shared/errors/AuthenticationError";
@@ -41,6 +42,10 @@ const matchRepository = new MatchPostgresRepository();
 const hash = new Hash();
 const jwt = new JWT(config.jwt);
 const userBanRepository = new UserBanPostgresRepository();
+const resetPasswordLinkBuilder = new ResetPasswordLinkBuilder(
+	config.passwordRecovery.frontends,
+	config.passwordRecovery.defaultResetUrl,
+);
 
 export const userRouter = new Elysia({ prefix: "/users" })
 	// Public Endpoints
@@ -116,8 +121,11 @@ export const userRouter = new Elysia({ prefix: "/users" })
 	.post(
 		"/forgot-password",
 		async ({ body, request }) => {
-			const baseUrl = request.headers.get("origin") || request.headers.get("referer") || "";
-			return new UserForgotPassword(userRepository, emailSender, jwt, logger, baseUrl).forgotPassword(body);
+			return new UserForgotPassword(userRepository, emailSender, jwt, logger, resetPasswordLinkBuilder).forgotPassword({
+				...body,
+				origin: request.headers.get("origin"),
+				referer: request.headers.get("referer"),
+			});
 		},
 		{
 			detail: {

--- a/tests/unit/modules/users/application/UserForgotPassword.test.ts
+++ b/tests/unit/modules/users/application/UserForgotPassword.test.ts
@@ -5,7 +5,6 @@ import { ResetPasswordLinkBuilder } from "../../../../../src/modules/user/domain
 import { User } from "../../../../../src/modules/user/domain/User";
 import { UserRepository } from "../../../../../src/modules/user/domain/UserRepository";
 import { EmailSender } from "../../../../../src/shared/email/domain/EmailSender";
-import { NotFoundError } from "../../../../../src/shared/errors/NotFoundError";
 import { JWT } from "../../../../../src/shared/JWT";
 import { Logger } from "../../../../../src/shared/logger/domain/Logger";
 import { Pino } from "../../../../../src/shared/logger/infrastructure/Pino";
@@ -67,10 +66,14 @@ describe("UserForgotPassword", () => {
 		expect(emailData.html).toContain("https://evolutionygo.com/reset-password?token=");
 	});
 
-	it("throws NotFoundError when the email is not registered", async () => {
+	it("does not reveal whether the email exists and skips sending when it is not registered", async () => {
 		spyOn(repository, "findByEmail").mockResolvedValue(null);
+		const sendSpy = spyOn(emailSender, "send").mockResolvedValue();
 
-		expect(forgot.forgotPassword({ email: "ghost@example.com" })).rejects.toThrow(NotFoundError);
+		const result = await forgot.forgotPassword({ email: "ghost@example.com" });
+
+		expect(result.message).toBe("Email sent successfully");
+		expect(sendSpy).not.toHaveBeenCalled();
 	});
 
 	it("propagates an error when the email fails to send", async () => {

--- a/tests/unit/modules/users/application/UserForgotPassword.test.ts
+++ b/tests/unit/modules/users/application/UserForgotPassword.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+import { UserForgotPassword } from "../../../../../src/modules/user/application/UserForgotPassword";
+import { ResetPasswordLinkBuilder } from "../../../../../src/modules/user/domain/ResetPasswordLinkBuilder";
+import { User } from "../../../../../src/modules/user/domain/User";
+import { UserRepository } from "../../../../../src/modules/user/domain/UserRepository";
+import { EmailSender } from "../../../../../src/shared/email/domain/EmailSender";
+import { NotFoundError } from "../../../../../src/shared/errors/NotFoundError";
+import { JWT } from "../../../../../src/shared/JWT";
+import { Logger } from "../../../../../src/shared/logger/domain/Logger";
+import { Pino } from "../../../../../src/shared/logger/infrastructure/Pino";
+import { UserMother } from "../mothers/UserMother";
+
+describe("UserForgotPassword", () => {
+	let repository: UserRepository;
+	let emailSender: EmailSender;
+	let jwt: JWT;
+	let logger: Logger;
+	let resetLinkBuilder: ResetPasswordLinkBuilder;
+	let forgot: UserForgotPassword;
+	let user: User;
+
+	beforeEach(() => {
+		repository = {
+			create: async () => undefined,
+			findByEmailOrUsername: async () => null,
+			findByEmail: async () => null,
+			findById: async () => null,
+			update: async () => undefined,
+			updateParticipantId: async () => undefined,
+			findByParticipantId: async () => null,
+		};
+		emailSender = { send: async () => undefined };
+		jwt = new JWT({ issuer: "issuer", secret: "secret" });
+		logger = new Pino();
+		resetLinkBuilder = new ResetPasswordLinkBuilder(
+			[
+				{ origin: "https://evolutionygo.com", template: "https://evolutionygo.com/reset-password?token={token}" },
+				{ origin: "https://evoduel.com", template: "https://evoduel.com/#/reset-account-password?token={token}" },
+			],
+			"https://evolutionygo.com/reset-password?token={token}",
+		);
+		forgot = new UserForgotPassword(repository, emailSender, jwt, logger, resetLinkBuilder);
+
+		user = UserMother.create();
+	});
+
+	it("emails the evoduel account-password reset link when the request comes from evoduel", async () => {
+		spyOn(repository, "findByEmail").mockResolvedValue(user);
+		const sendSpy = spyOn(emailSender, "send").mockResolvedValue();
+
+		await forgot.forgotPassword({ email: user.email, origin: "https://evoduel.com", referer: null });
+
+		expect(sendSpy).toHaveBeenCalledTimes(1);
+		const emailData = sendSpy.mock.calls[0][1];
+		expect(emailData.html).toContain("https://evoduel.com/#/reset-account-password?token=");
+		expect(emailData.text).toContain("https://evoduel.com/#/reset-account-password?token=");
+	});
+
+	it("preserves the evolutionygo reset-password link when the request only carries a referer", async () => {
+		spyOn(repository, "findByEmail").mockResolvedValue(user);
+		const sendSpy = spyOn(emailSender, "send").mockResolvedValue();
+
+		await forgot.forgotPassword({ email: user.email, origin: null, referer: "https://evolutionygo.com/" });
+
+		const emailData = sendSpy.mock.calls[0][1];
+		expect(emailData.html).toContain("https://evolutionygo.com/reset-password?token=");
+	});
+
+	it("throws NotFoundError when the email is not registered", async () => {
+		spyOn(repository, "findByEmail").mockResolvedValue(null);
+
+		expect(forgot.forgotPassword({ email: "ghost@example.com" })).rejects.toThrow(NotFoundError);
+	});
+
+	it("propagates an error when the email fails to send", async () => {
+		spyOn(repository, "findByEmail").mockResolvedValue(user);
+		spyOn(emailSender, "send").mockRejectedValue(new Error("smtp down"));
+
+		expect(
+			forgot.forgotPassword({ email: user.email, origin: "https://evoduel.com" }),
+		).rejects.toThrow("Error sending email");
+	});
+});

--- a/tests/unit/modules/users/domain/ResetPasswordLinkBuilder.test.ts
+++ b/tests/unit/modules/users/domain/ResetPasswordLinkBuilder.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+
+import { ResetPasswordLinkBuilder } from "../../../../../src/modules/user/domain/ResetPasswordLinkBuilder";
+
+describe("ResetPasswordLinkBuilder", () => {
+	const builder = new ResetPasswordLinkBuilder(
+		[
+			{ origin: "https://evolutionygo.com", template: "https://evolutionygo.com/reset-password?token={token}" },
+			{ origin: "https://evoduel.com", template: "https://evoduel.com/#/reset-account-password?token={token}" },
+		],
+		"https://evolutionygo.com/reset-password?token={token}",
+	);
+
+	it("builds the link for a known origin header", () => {
+		const link = builder.build({ origin: "https://evoduel.com", referer: null, token: "abc" });
+
+		expect(link).toBe("https://evoduel.com/#/reset-account-password?token=abc");
+	});
+
+	it("derives the origin from the referer when the origin header is absent", () => {
+		const link = builder.build({ origin: null, referer: "https://evolutionygo.com/", token: "abc" });
+
+		expect(link).toBe("https://evolutionygo.com/reset-password?token=abc");
+	});
+
+	it("prefers the origin header over the referer", () => {
+		const link = builder.build({ origin: "https://evoduel.com", referer: "https://evolutionygo.com/", token: "abc" });
+
+		expect(link).toBe("https://evoduel.com/#/reset-account-password?token=abc");
+	});
+
+	it("falls back to the default template for an unknown origin", () => {
+		const link = builder.build({ origin: "https://evil.com", referer: null, token: "abc" });
+
+		expect(link).toBe("https://evolutionygo.com/reset-password?token=abc");
+	});
+
+	it("falls back to the default when neither origin nor referer are present", () => {
+		const link = builder.build({ origin: null, referer: null, token: "abc" });
+
+		expect(link).toBe("https://evolutionygo.com/reset-password?token=abc");
+	});
+
+	it("falls back to the default when the referer is malformed", () => {
+		const link = builder.build({ origin: null, referer: "not-a-url", token: "abc" });
+
+		expect(link).toBe("https://evolutionygo.com/reset-password?token=abc");
+	});
+
+	it("matches the origin ignoring trailing slash and case", () => {
+		const link = builder.build({ origin: "https://EVODUEL.com/", referer: null, token: "abc" });
+
+		expect(link).toBe("https://evoduel.com/#/reset-account-password?token=abc");
+	});
+});


### PR DESCRIPTION
## Summary

The forgot-password flow had two problems:

1. **The recovery email link was built from the raw `Origin`/`Referer` header** and always pointed at `/reset-password`. That link is spoofable (reset poisoning) and can only serve a single frontend — it breaks now that the API serves two distinct frontends with different routing.
2. **`forgot-password` revealed whether an email was registered** (`404` for unknown vs `200` for known), allowing account enumeration.

This PR fixes both, without changing any frontend contract (the request `Origin`/`Referer` already travels automatically).

## What changed

- A per-origin registry (`ResetPasswordLinkBuilder`) now builds the recovery link. The request origin is resolved from `Origin` (falling back to the `Referer` host) and used **only to select** the frontend — the URL itself always comes from config, never from the raw header. Unknown/spoofed origins fall back to a safe default.
- `forgot-password` now returns the same success response whether or not the email exists, and skips sending when it does not.
- The email send is now awaited, so a delivery failure surfaces to the caller instead of being swallowed by an un-awaited `.catch`.

| File | Change |
|------|--------|
| `src/modules/user/domain/ResetPasswordLinkBuilder.ts` | New. Pure origin→reset-URL resolution with safe default |
| `src/modules/user/application/UserForgotPassword.ts` | Use the builder, await the email, stop leaking email existence |
| `src/config/index.ts` | `passwordRecovery` registry (per-frontend reset URLs, by env) |
| `src/server/routes/user-router.ts` | Wire the builder, pass `origin`/`referer` to the use case |
| `tests/.../ResetPasswordLinkBuilder.test.ts` | New. 7 cases |
| `tests/.../UserForgotPassword.test.ts` | New. 4 cases |

## Behavior change to note

For unknown emails, `forgot-password` now returns `200` instead of `404`. This is intentional — anti-enumeration requires the responses to be indistinguishable.

## Test plan

- [x] `bun test` → 201 pass / 0 fail
- [x] `bunx tsc --noEmit` → 0 errors
- [x] `bun run lint` → clean