### PR TITLE
feat(auth): return a fresh session from reset-account-password

### DIFF
--- a/src/modules/user/application/UserAccountPasswordReset.ts
+++ b/src/modules/user/application/UserAccountPasswordReset.ts
@@ -16,7 +16,13 @@ export class UserAccountPasswordReset {
 		private readonly jwt: JWT,
 	) {}
 
-	async resetPassword({ token, newPassword }: { token: string; newPassword: string }): Promise<void> {
+	async resetPassword({
+		token,
+		newPassword,
+	}: {
+		token: string;
+		newPassword: string;
+	}): Promise<{ id: string; username: string; token: string }> {
 		if (!token) {
 			throw new AuthenticationError("No token provided");
 		}
@@ -31,7 +37,8 @@ export class UserAccountPasswordReset {
 		const securePassword = SecurePassword.create(newPassword);
 		const securePasswordHashed = await this.hash.hash(securePassword.value);
 
-		await this.repository.update(user.updateSecurePassword(securePasswordHashed));
+		const updatedUser = user.updateSecurePassword(securePasswordHashed);
+		await this.repository.update(updatedUser);
 		this.logger.info(`Account password reset for user: ${user.id}`);
 
 		const emailData = {
@@ -42,5 +49,9 @@ export class UserAccountPasswordReset {
 		};
 
 		await this.emailSender.send(user.email, emailData);
+
+		const sessionToken = this.jwt.generate({ id: updatedUser.id, role: updatedUser.role });
+
+		return { id: updatedUser.id, token: sessionToken, username: updatedUser.username };
 	}
 }

--- a/src/server/routes/user-router.ts
+++ b/src/server/routes/user-router.ts
@@ -232,7 +232,18 @@ export const userRouter = new Elysia({ prefix: "/users" })
 				description: 'Resets the strong account password using a valid reset token',
 				security: [{ bearerAuth: [] }],
 				responses: {
-					200: { description: 'Account password reset successfully' },
+					200: {
+						description: 'Account password reset successfully; returns a fresh session for auto-login',
+						content: {
+							'application/json': {
+								example: {
+									id: 'user-123',
+									username: 'player1',
+									token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
+								}
+							}
+						}
+					},
 					400: { description: 'Password does not meet the policy' },
 					401: { description: 'Invalid or expired token' }
 				}

--- a/tests/unit/modules/users/application/UserAccountPasswordReset.test.ts
+++ b/tests/unit/modules/users/application/UserAccountPasswordReset.test.ts
@@ -55,6 +55,18 @@ describe("UserAccountPasswordReset", () => {
 		expect(await hash.compare("NewPass2024", updatedUser.securePassword as string)).toBe(true);
 	});
 
+	it("returns a fresh session so the client can auto-login", async () => {
+		spyOn(repository, "findById").mockResolvedValue(user);
+
+		const session = await reset.resetPassword({ token, newPassword: "NewPass2024" });
+
+		expect(session.id).toBe(user.id);
+		expect(session.username).toBe(user.username);
+		const decoded = jwt.decode(session.token) as { id: string; role: string };
+		expect(decoded.id).toBe(user.id);
+		expect(decoded.role).toBe(user.role);
+	});
+
 	it("throws when no token is provided", async () => {
 		expect(reset.resetPassword({ token: "", newPassword: "NewPass2024" })).rejects.toThrow(AuthenticationError);
 	});


### PR DESCRIPTION
## Summary

After a user resets their account password through the recovery email link, the client wants to **auto-login** the user and send them to their profile. It could not: it only has the reset token (carries `userId`, not email) plus the new password, and `login()` requires the email — while `validate-token` returns `{ valid, userId }`, not the email.

This makes `reset-account-password` return a fresh session itself, in a single round-trip, symmetric with `upgrade-password`.

## What changed

- `POST /api/v1/users/reset-account-password` now returns `{ id, username, token }` (JWT `{ id, role }`) after setting `secure_password`, instead of `void`.
- Same shape and behavior as `upgrade-password`, so the client reuses the existing session-handling path.

| File | Change |
|------|--------|
| `src/modules/user/application/UserAccountPasswordReset.ts` | Generate and return the session token |
| `src/server/routes/user-router.ts` | Document the new `200` response shape (the route already returned the use-case result) |
| `tests/.../UserAccountPasswordReset.test.ts` | New test: returns a session with a valid JWT |

## Notes

- The client is already built to consume this: if a session comes back, it auto-logins; if not, it falls back to "go to login". So this is non-blocking for the client.
- `reset-account-password` already doubled as an alternative migration path (it sets `secure_password` even when it was `null`); such users now also come back authenticated.

## Test plan

- [x] `bun test` → 213 pass / 0 fail
- [x] `bunx tsc --noEmit` → 0 errors
- [x] `bun run lint` → clean