### PR TITLE
feat(auth): return migrated flag from reset-account-password

### DIFF
--- a/src/modules/user/application/UserAccountPasswordReset.ts
+++ b/src/modules/user/application/UserAccountPasswordReset.ts
@@ -22,7 +22,7 @@ export class UserAccountPasswordReset {
 	}: {
 		token: string;
 		newPassword: string;
-	}): Promise<{ id: string; username: string; token: string }> {
+	}): Promise<{ id: string; username: string; token: string; migrated: boolean }> {
 		if (!token) {
 			throw new AuthenticationError("No token provided");
 		}
@@ -33,6 +33,9 @@ export class UserAccountPasswordReset {
 			this.logger.error(`User not found for account password reset: ${decoded.id}`);
 			throw new NotFoundError("User not found");
 		}
+
+		// null = the user never had an account password, so this reset is their first migration.
+		const migrated = user.securePassword === null;
 
 		const securePassword = SecurePassword.create(newPassword);
 		const securePasswordHashed = await this.hash.hash(securePassword.value);
@@ -52,6 +55,6 @@ export class UserAccountPasswordReset {
 
 		const sessionToken = this.jwt.generate({ id: updatedUser.id, role: updatedUser.role });
 
-		return { id: updatedUser.id, token: sessionToken, username: updatedUser.username };
+		return { id: updatedUser.id, token: sessionToken, username: updatedUser.username, migrated };
 	}
 }

--- a/src/server/routes/user-router.ts
+++ b/src/server/routes/user-router.ts
@@ -239,7 +239,8 @@ export const userRouter = new Elysia({ prefix: "/users" })
 								example: {
 									id: 'user-123',
 									username: 'player1',
-									token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
+									token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+									migrated: true
 								}
 							}
 						}

--- a/tests/unit/modules/users/application/UserAccountPasswordReset.test.ts
+++ b/tests/unit/modules/users/application/UserAccountPasswordReset.test.ts
@@ -67,6 +67,24 @@ describe("UserAccountPasswordReset", () => {
 		expect(decoded.role).toBe(user.role);
 	});
 
+	it("flags migrated=true when the user had no account password yet (first migration)", async () => {
+		spyOn(repository, "findById").mockResolvedValue(user);
+
+		const session = await reset.resetPassword({ token, newPassword: "NewPass2024" });
+
+		expect(session.migrated).toBe(true);
+	});
+
+	it("flags migrated=false when the user already had an account password", async () => {
+		const existingUser = UserMother.create({ securePassword: await hash.hash("OldPass2024") });
+		const existingUserToken = jwt.generate({ id: existingUser.id });
+		spyOn(repository, "findById").mockResolvedValue(existingUser);
+
+		const session = await reset.resetPassword({ token: existingUserToken, newPassword: "NewPass2024" });
+
+		expect(session.migrated).toBe(false);
+	});
+
 	it("throws when no token is provided", async () => {
 		expect(reset.resetPassword({ token: "", newPassword: "NewPass2024" })).rejects.toThrow(AuthenticationError);
 	});


### PR DESCRIPTION
## Summary

`reset-account-password` already returns a session (`{ id, username, token }`). This adds a `migrated` boolean so the client can tell a **first-time migration** apart from a **reset of an existing account**.

- `migrated: true` → the user had no account password before this reset (first migration).
- `migrated: false` → the user already had one (a normal reset).

## Why

The client's "your game password no longer exists, regenerate it" banner is only correct for a user who just migrated and lost their PIN. Showing it to an already-migrated user (whose PIN still works) could push them to regenerate it and break their login on external clients. The client gates the banner on `migrated === true`; without this flag it stays off for everyone.

## What changed

| File | Change |
|------|--------|
| `src/modules/user/application/UserAccountPasswordReset.ts` | Capture `migrated` from the pre-update user state and add it to the result |
| `src/server/routes/user-router.ts` | Document the `migrated` field in the `200` response |
| `tests/.../UserAccountPasswordReset.test.ts` | New tests: `migrated=true` (first migration) and `migrated=false` (existing account) |

## Final response contract

`{ id, username, token, migrated }`

## Test plan

- [x] `bun test` → 216 pass / 0 fail
- [x] `bunx tsc --noEmit` → 0 errors
- [x] `bun run lint` → clean