### PR TITLE
fix: ignore www subdomain when matching reset password frontend origin

### DIFF
--- a/src/modules/user/domain/ResetPasswordLinkBuilder.ts
+++ b/src/modules/user/domain/ResetPasswordLinkBuilder.ts
@@ -40,6 +40,10 @@ export class ResetPasswordLinkBuilder {
 	}
 
 	private normalize(value: string): string {
-		return value.trim().toLowerCase().replace(/\/+$/, "");
+		return value
+			.trim()
+			.toLowerCase()
+			.replace(/\/+$/, "")
+			.replace(/^(https?:\/\/)www\./, "$1");
 	}
 }

--- a/tests/unit/modules/users/domain/ResetPasswordLinkBuilder.test.ts
+++ b/tests/unit/modules/users/domain/ResetPasswordLinkBuilder.test.ts
@@ -52,4 +52,16 @@ describe("ResetPasswordLinkBuilder", () => {
 
 		expect(link).toBe("https://evoduel.com/#/reset-account-password?token=abc");
 	});
+
+	it("matches the origin ignoring the www subdomain", () => {
+		const link = builder.build({ origin: "https://www.evoduel.com", referer: null, token: "abc" });
+
+		expect(link).toBe("https://evoduel.com/#/reset-account-password?token=abc");
+	});
+
+	it("derives the origin from a www referer ignoring the subdomain", () => {
+		const link = builder.build({ origin: null, referer: "https://www.evoduel.com/", token: "abc" });
+
+		expect(link).toBe("https://evoduel.com/#/reset-account-password?token=abc");
+	});
 });


### PR DESCRIPTION
## Problema

Las peticiones a `POST /users/forgot-password` desde **`https://www.evoduel.com`** (con `www`) llegaban con el link de reset de **evolutionygo.com** en lugar del de evoduel.

### Causa raíz

`ResetPasswordLinkBuilder.normalize()` solo hacía `trim` / `lowercase` / quitar barra final, pero **no eliminaba el prefijo `www.`**. El registro de frontends (`src/config/index.ts`) tiene `origin: "https://evoduel.com"` sin `www`, entonces `https://www.evoduel.com` no matcheaba ningún entry y `build()` caía al `defaultResetUrl` (evolutionygo.com).

El header `Origin` y el `Referer` servidos desde un frontend con `www` arrastran ese `www`, así que el bug afectaba ambos caminos de resolución.

## Solución

Normalizar el prefijo `www.` tanto en los origins del registro como en el `origin`/`referer` entrante, de modo que el host apex y el `www` resuelvan al mismo frontend. Más robusto que agregar entries explícitas: cubre cualquier dominio sin mantenimiento por variante.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `src/modules/user/domain/ResetPasswordLinkBuilder.ts` | `normalize()` ahora quita el prefijo `www.` |
| `tests/unit/modules/users/domain/ResetPasswordLinkBuilder.test.ts` | +2 tests (www en `origin` y en `referer`) |

## Test plan

- [x] TDD: tests del caso `www` escritos primero (RED), reproducían el bug exacto (recibían `evolutionygo.com`)
- [x] `bun test` builder: 9/9 verde, 100% coverage
- [x] `bun test` suite de users completa: 104/104 verde

## Notas de deploy

Requiere **rebuild + redeploy** del contenedor `evolutionygo-api` para llegar a prod (corre la imagen ya buildeada).