### PR TITLE
feat: add avatar cosmetics to standard catalog seed

### DIFF
--- a/src/modules/catalog/application/standardCosmetics.ts
+++ b/src/modules/catalog/application/standardCosmetics.ts
@@ -26,4 +26,9 @@ export const STANDARD_COSMETICS: StandardCosmeticSeed[] = [
 	{ type: CosmeticType.PLAYMAT, tier: CosmeticTier.STANDARD, assetRef: "playmats/pallet-covered-b/", displayName: "Pallet Covered B" },
 	{ type: CosmeticType.PLAYMAT, tier: CosmeticTier.STANDARD, assetRef: "playmats/pallet-wood/", displayName: "Pallet Wood" },
 	{ type: CosmeticType.PLAYMAT, tier: CosmeticTier.STANDARD, assetRef: "playmats/plaque/", displayName: "Plaque" },
+	{ type: CosmeticType.AVATAR, tier: CosmeticTier.REGISTERED, assetRef: "avatars/baby-frog/", displayName: "Baby Frog" },
+	{ type: CosmeticType.AVATAR, tier: CosmeticTier.REGISTERED, assetRef: "avatars/kagura/", displayName: "Kagura" },
+	{ type: CosmeticType.AVATAR, tier: CosmeticTier.REGISTERED, assetRef: "avatars/mystical-witch/", displayName: "Mystical Witch" },
+	{ type: CosmeticType.AVATAR, tier: CosmeticTier.STANDARD, assetRef: "avatars/evolution/", displayName: "Evolution" },
+	{ type: CosmeticType.AVATAR, tier: CosmeticTier.STANDARD, assetRef: "avatars/evolution-black/", displayName: "Evolution Black" },
 ];


### PR DESCRIPTION
## Summary
- Adds 5 `AVATAR` cosmetics to the standard catalog seed (`STANDARD_COSMETICS`), enabling them in the catalog and loadout.
- Tiers mirror the homonymous sleeves: `baby-frog`, `kagura`, `mystical-witch` → `REGISTERED`; `evolution`, `evolution-black` → `STANDARD`.
- No schema change: the `AVATAR` enum value and `cosmetics` table already exist. The cosmetics system is type-agnostic (seed matches by `asset_ref`, signer signs any `preview`/`render` under the prefix, equip validates slot + entitlement generically), so no serve-path change was needed.

## Changes
| File | Change |
|------|--------|
| `src/modules/catalog/application/standardCosmetics.ts` | Append 5 `AVATAR` seed entries |

## Runtime
Assets already live in the R2 bucket under `avatars/<name>/{preview,render}.jpg`. After deploy, run the idempotent seed to insert the rows (skips existing `asset_ref`s):

```
bun run seed:cosmetics
```

Note: the seed never updates the tier of an already-seeded cosmetic — changing a tier after first seed requires a data migration (see `SetSleeveTiers`).

## Test plan
- [x] `bun test tests/unit/modules/catalog tests/unit/server/routes/me-cosmetics-router.test.ts` — 26 pass, 0 fail
- [x] Lint clean (pre-commit hook)
- [ ] CI: lint + tests + build