### PR TITLE
feat: username availability endpoint + 409 on taken username

### DIFF
--- a/src/modules/user/application/UserUsernameAvailabilityChecker.ts
+++ b/src/modules/user/application/UserUsernameAvailabilityChecker.ts
@@ -1,0 +1,11 @@
+import { UserRepository } from "../domain/UserRepository";
+
+export class UserUsernameAvailabilityChecker {
+	constructor(private readonly repository: UserRepository) {}
+
+	async check({ username }: { username: string }): Promise<{ available: boolean }> {
+		const user = await this.repository.findByUsername(username);
+
+		return { available: user === null };
+	}
+}

--- a/src/modules/user/application/UserUsernameUpdater.ts
+++ b/src/modules/user/application/UserUsernameUpdater.ts
@@ -1,3 +1,4 @@
+import { ConflictError } from "../../../shared/errors/ConflictError";
 import { NotFoundError } from "../../../shared/errors/NotFoundError";
 import { UserRepository } from "../domain/UserRepository";
 
@@ -9,6 +10,12 @@ export class UserUsernameUpdater {
 
 		if (!user) {
 			throw new NotFoundError(`user with id ${id} not found`);
+		}
+
+		const usernameOwner = await this.repository.findByUsername(username);
+
+		if (usernameOwner && usernameOwner.id !== id) {
+			throw new ConflictError(`username ${username} is already taken`);
 		}
 
 		user.updateUsername(username);

--- a/src/modules/user/domain/UserRepository.ts
+++ b/src/modules/user/domain/UserRepository.ts
@@ -4,6 +4,7 @@ export interface UserRepository {
 	create(user: User): Promise<void>;
 	findByEmailOrUsername(email: string, username: string): Promise<User | null>;
 	findByEmail(email: string): Promise<User | null>;
+	findByUsername(username: string): Promise<User | null>;
 	findById(id: string): Promise<User | null>;
 	update(user: User): Promise<void>;
 	updateParticipantId(userId: string, participantId: string): Promise<void>;

--- a/src/modules/user/infrastructure/UserPostgresRepository.ts
+++ b/src/modules/user/infrastructure/UserPostgresRepository.ts
@@ -44,6 +44,21 @@ export class UserPostgresRepository implements UserRepository {
 		return User.from(userProfileEntity);
 	}
 
+	async findByUsername(username: string): Promise<User | null> {
+		const repository = dataSource.getRepository(UserProfileEntity);
+		const userProfileEntity = await repository.findOne({
+			where: {
+				username,
+			},
+		});
+
+		if (!userProfileEntity) {
+			return null;
+		}
+
+		return User.from(userProfileEntity);
+	}
+
 	async findById(id: string): Promise<User | null> {
 		const repository = dataSource.getRepository(UserProfileEntity);
 		const userProfileEntity = await repository.findOne({

--- a/src/server/routes/user-router.ts
+++ b/src/server/routes/user-router.ts
@@ -16,6 +16,7 @@ import { UserAccountPasswordUpdater } from "../../modules/user/application/UserA
 import { UserUpgradePassword } from "../../modules/user/application/UserUpgradePassword";
 import { UserTokenValidator } from "../../modules/user/application/UserTokenValidator";
 import { UserUsernameUpdater } from "../../modules/user/application/UserUsernameUpdater";
+import { UserUsernameAvailabilityChecker } from "../../modules/user/application/UserUsernameAvailabilityChecker";
 import { ResetPasswordLinkBuilder } from "../../modules/user/domain/ResetPasswordLinkBuilder";
 import { UserPostgresRepository } from "../../modules/user/infrastructure/UserPostgresRepository";
 import { ResendEmailSender } from "../../shared/email/infrastructure/ResendEmailSender";
@@ -174,6 +175,32 @@ export const userRouter = new Elysia({ prefix: "/users" })
 			},
 			query: t.Object({
 				token: t.String(),
+			}),
+		},
+	)
+	.get(
+		"/username-availability",
+		async ({ query }) => {
+			return new UserUsernameAvailabilityChecker(userRepository).check({ username: query.username });
+		},
+		{
+			detail: {
+				tags: ['User Management'],
+				summary: 'Check username availability',
+				description: 'Checks whether a username is available so the frontend can validate it before submitting a change or registration',
+				responses: {
+					200: {
+						description: 'Availability resolved successfully',
+						content: {
+							'application/json': {
+								example: { available: true }
+							}
+						}
+					}
+				}
+			},
+			query: t.Object({
+				username: t.String({ minLength: 1, maxLength: 14, pattern: '^.*\\S.*$' }),
 			}),
 		},
 	)

--- a/tests/unit/modules/auth/application/UserAuth.test.ts
+++ b/tests/unit/modules/auth/application/UserAuth.test.ts
@@ -24,6 +24,7 @@ describe("UserAuth", () => {
       create: async () => { },
       findByEmailOrUsername: async () => null,
       findByEmail: async () => null,
+      findByUsername: async () => null,
       findById: async () => null,
       update: async () => { },
       updateParticipantId: async () => { },

--- a/tests/unit/modules/users/application/UserAccountPasswordReset.test.ts
+++ b/tests/unit/modules/users/application/UserAccountPasswordReset.test.ts
@@ -28,6 +28,7 @@ describe("UserAccountPasswordReset", () => {
 			create: async () => undefined,
 			findByEmailOrUsername: async () => null,
 			findByEmail: async () => null,
+			findByUsername: async () => null,
 			findById: async () => null,
 			update: async () => undefined,
 			updateParticipantId: async () => undefined,

--- a/tests/unit/modules/users/application/UserAccountPasswordUpdater.test.ts
+++ b/tests/unit/modules/users/application/UserAccountPasswordUpdater.test.ts
@@ -27,6 +27,7 @@ describe("UserAccountPasswordUpdater", () => {
 			create: async () => undefined,
 			findByEmailOrUsername: async () => null,
 			findByEmail: async () => null,
+			findByUsername: async () => null,
 			findById: async () => null,
 			update: async () => undefined,
 			updateParticipantId: async () => undefined,

--- a/tests/unit/modules/users/application/UserForgotPassword.test.ts
+++ b/tests/unit/modules/users/application/UserForgotPassword.test.ts
@@ -24,6 +24,7 @@ describe("UserForgotPassword", () => {
 			create: async () => undefined,
 			findByEmailOrUsername: async () => null,
 			findByEmail: async () => null,
+			findByUsername: async () => null,
 			findById: async () => null,
 			update: async () => undefined,
 			updateParticipantId: async () => undefined,

--- a/tests/unit/modules/users/application/UserGamePasswordGenerator.test.ts
+++ b/tests/unit/modules/users/application/UserGamePasswordGenerator.test.ts
@@ -17,6 +17,7 @@ describe("UserGamePasswordGenerator", () => {
 			create: async () => undefined,
 			findByEmailOrUsername: async () => null,
 			findByEmail: async () => null,
+			findByUsername: async () => null,
 			findById: async () => null,
 			update: async () => undefined,
 			updateParticipantId: async () => undefined,

--- a/tests/unit/modules/users/application/UserRegister.test.ts
+++ b/tests/unit/modules/users/application/UserRegister.test.ts
@@ -27,6 +27,7 @@ describe("UserRegister", () => {
 			create: async () => undefined,
 			findByEmailOrUsername: async () => null,
 			findByEmail: async () => null,
+			findByUsername: async () => null,
 			findById: async () => null,
 			update: async () => undefined,
 			updateParticipantId: async () => undefined,

--- a/tests/unit/modules/users/application/UserUpgradePassword.test.ts
+++ b/tests/unit/modules/users/application/UserUpgradePassword.test.ts
@@ -21,6 +21,7 @@ describe("UserUpgradePassword", () => {
 			create: async () => undefined,
 			findByEmailOrUsername: async () => null,
 			findByEmail: async () => null,
+			findByUsername: async () => null,
 			findById: async () => null,
 			update: async () => undefined,
 			updateParticipantId: async () => undefined,

--- a/tests/unit/modules/users/application/UserUsernameAvailabilityChecker.test.ts
+++ b/tests/unit/modules/users/application/UserUsernameAvailabilityChecker.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+import { UserUsernameAvailabilityChecker } from "../../../../../src/modules/user/application/UserUsernameAvailabilityChecker";
+import { UserRepository } from "../../../../../src/modules/user/domain/UserRepository";
+import { UserMother } from "../mothers/UserMother";
+
+describe("UserUsernameAvailabilityChecker", () => {
+	let repository: UserRepository;
+	let checker: UserUsernameAvailabilityChecker;
+
+	beforeEach(() => {
+		repository = {
+			create: async () => undefined,
+			findByEmailOrUsername: async () => null,
+			findByEmail: async () => null,
+			findById: async () => null,
+			findByUsername: async () => null,
+			update: async () => undefined,
+			updateParticipantId: async () => undefined,
+			findByParticipantId: async () => null,
+		};
+		checker = new UserUsernameAvailabilityChecker(repository);
+	});
+
+	it("returns available true when no user owns the username", async () => {
+		spyOn(repository, "findByUsername").mockResolvedValue(null);
+
+		const result = await checker.check({ username: "free-name" });
+
+		expect(result).toEqual({ available: true });
+	});
+
+	it("returns available false when the username is already taken", async () => {
+		spyOn(repository, "findByUsername").mockResolvedValue(UserMother.create());
+
+		const result = await checker.check({ username: "taken-name" });
+
+		expect(result).toEqual({ available: false });
+	});
+
+	it("looks the username up through the repository", async () => {
+		const findByUsernameSpy = spyOn(repository, "findByUsername");
+
+		await checker.check({ username: "some-name" });
+
+		expect(findByUsernameSpy).toHaveBeenCalledWith("some-name");
+	});
+});

--- a/tests/unit/modules/users/application/UserUsernameUpdater.test.ts
+++ b/tests/unit/modules/users/application/UserUsernameUpdater.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { UserUsernameUpdater } from "../../../../../src/modules/user/application/UserUsernameUpdater";
 import { User } from "../../../../../src/modules/user/domain/User";
 import { UserRepository } from "../../../../../src/modules/user/domain/UserRepository";
+import { ConflictError } from "../../../../../src/shared/errors/ConflictError";
 import { UserMother } from "../mothers/UserMother";
 import { UserUsernameUpdaterRequestMother } from "../mothers/UserUsernameUpdaterRequestMother";
 
@@ -17,6 +18,7 @@ describe("User UsernameUpdater", () => {
 			create: async () => undefined,
 			findByEmailOrUsername: async () => null,
 			findByEmail: async () => null,
+			findByUsername: async () => null,
 			findById: async () => null,
 			update: async () => undefined,
 			updateParticipantId: async () => undefined,
@@ -39,5 +41,23 @@ describe("User UsernameUpdater", () => {
 				username: request.username,
 			}),
 		);
+	});
+
+	it("throws a ConflictError when the username is already taken by another user", async () => {
+		const anotherUser = UserMother.create();
+		spyOn(repository, "findByUsername").mockResolvedValue(anotherUser);
+		const repositoryUpdateSpy = spyOn(repository, "update");
+
+		await expect(userUsernameUpdater.updateUsername(request)).rejects.toThrow(ConflictError);
+		expect(repositoryUpdateSpy).not.toHaveBeenCalled();
+	});
+
+	it("allows a user to keep their own username without conflict", async () => {
+		spyOn(repository, "findByUsername").mockResolvedValue(user);
+		const repositoryUpdateSpy = spyOn(repository, "update");
+
+		await userUsernameUpdater.updateUsername({ id: user.id, username: user.username });
+
+		expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary
- Adds a public `GET /users/username-availability?username=xxx` endpoint returning `{ available: boolean }` so the frontend can validate a username before a change or registration.
- Hardens `change-username`: pre-checks availability and returns a clean **409** (`ConflictError`) when the username is owned by another user, instead of letting the DB unique constraint surface a raw 500.

## Changes
- `domain/UserRepository`: new `findByUsername`
- `infrastructure/UserPostgresRepository`: `findByUsername` implementation
- `application/UserUsernameAvailabilityChecker`: new use case (`{ available: boolean }`)
- `application/UserUsernameUpdater`: conflict pre-check (keeping your own username stays a safe no-op)
- `server/routes/user-router`: new public route, validated with the same rules as register/change-username
- Unit tests for both use cases (availability + conflict path)

## Notes
- `ConflictError -> 409` is wired globally in `server.ts` via the Elysia `.onError` handler.
- The pre-check does not fully close the check-then-update race; the `users.username` unique constraint remains the final backstop (same trade-off `UserRegister` already lives with).

## Test plan
- `bun test` -> 244 pass / 0 fail
- `bun run lint` -> 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
