### PR TITLE
fix: return 403 (not 401) for banned users in banGuard

### DIFF
--- a/src/server/guards/bandGuard.ts
+++ b/src/server/guards/bandGuard.ts
@@ -1,11 +1,12 @@
 import { UserBanPostgresRepository } from "../../modules/user/infrastructure/UserBanPostgresRepository";
 import { UserGetActiveBan } from "../../modules/user/application/UserGetActiveBan";
 import { AuthenticationError } from "../../shared/errors/AuthenticationError";
+import { ForbiddenError } from "../../shared/errors/ForbiddenError";
 import { config } from "../../config";
 import { JWT } from "../../shared/JWT";
 
 export const banGuard = {
-  async beforeHandle({ set, bearer }) {
+  async beforeHandle({ bearer }) {
     const bearerToken = bearer as string | undefined;
     if (!bearerToken) throw new AuthenticationError("No token provided");
     const jwt = new JWT(config.jwt);
@@ -20,8 +21,7 @@ export const banGuard = {
     const getActiveBan = new UserGetActiveBan(userBanRepository);
     const activeBan = await getActiveBan.execute(userId);
     if (activeBan) {
-      set.status = 403;
-      throw new AuthenticationError("User is banned");
+      throw new ForbiddenError("User is banned");
     }
   }
 };


### PR DESCRIPTION
## Problem
Banned users were meant to receive **403 Forbidden** from `banGuard`, but they actually got **401 Unauthorized**.

The guard did `set.status = 403` and then `throw new AuthenticationError("User is banned")`. The global `.onError` handler in `server.ts` maps `AuthenticationError -> 401`, and since it runs after the guard it **overrode** the 403 with a 401.

## Fix
- Throw `ForbiddenError` (already mapped to **403** by `.onError`) for the ban case, instead of `AuthenticationError`.
- Keep `AuthenticationError -> 401` for missing/invalid token (unauthenticated, not forbidden).
- Drop the now-redundant manual `set.status = 403` (and the unused `set` from the handler signature).

This matches the existing repo pattern: `EquipCosmetic` already throws `ForbiddenError` for 403.

## Impact
- Banned users now correctly receive **403**, so clients can distinguish "banned" from "bad/missing token".

## Notes on testing
No unit test added: `banGuard` instantiates its dependencies internally (`JWT`, `UserBanPostgresRepository`, `UserGetActiveBan`), so it is not unit-testable without DB access or `mock.module` — a pattern this repo does not use (it favors dependency injection + in-memory repositories). The `ForbiddenError -> 403` mapping is already exercised in production via `EquipCosmetic`. A proper follow-up would refactor `banGuard` to dependency injection and add a focused test.

## Test plan
- `bun test` -> 241 pass / 0 fail
- `bun run lint` -> 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
