### PR TITLE
build(deps): declare typescript as explicit devDependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "husky": "^9.1.7",
         "install": "^0.13.0",
         "lint-staged": "^16.2.7",
+        "typescript": "5.9.3",
         "typescript-eslint": "^8.54.0",
       },
     },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "husky": "^9.1.7",
     "install": "^0.13.0",
     "lint-staged": "^16.2.7",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.54.0"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

- Declare `typescript` as an explicit `devDependency` (exact `5.9.3`).

## Why

The `build` script runs `tsc`, but TypeScript was **not declared** in
`package.json` — it only arrived transitively via `typescript-eslint`
(peer `>=4.8.4 <6.1.0`). The build's own compiler hung on an accident of
the dependency tree: if the linter were upgraded, swapped, or removed,
the build would silently lose `tsc`.

## Why exact pin (no caret)

TypeScript does not follow strict semver — a minor bump (e.g. 5.9 → 5.10)
can introduce stricter type checks that break the build with no API
change. Pinning the compiler exactly is the recommended practice and
keeps CI deterministic, even though the rest of the repo uses carets.

This intentionally stays on **5.9.3** (the version already installed). A
move to TypeScript 6 is a separate decision, best paired with the linter
strategy (Biome vs typescript-eslint).

## Test plan

- [x] `bun run build` — tsc exits 0
- [x] `bun test` — 246 pass / 0 fail
- [x] `bun pm ls` confirms typescript@5.9.3 is now a direct dependency
