### PR TITLE
build(deps): upgrade TypeScript to 6.0.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "husky": "^9.1.7",
         "install": "^0.13.0",
         "lint-staged": "^16.2.7",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
       },
     },
   },
@@ -662,7 +662,7 @@
 
     "typeorm": ["typeorm@0.3.28", "", { "dependencies": { "@sqltools/formatter": "^1.2.5", "ansis": "^4.2.0", "app-root-path": "^3.1.0", "buffer": "^6.0.3", "dayjs": "^1.11.19", "debug": "^4.4.3", "dedent": "^1.7.0", "dotenv": "^16.6.1", "glob": "^10.5.0", "reflect-metadata": "^0.2.2", "sha.js": "^2.4.12", "sql-highlight": "^6.1.0", "tslib": "^2.8.1", "uuid": "^11.1.0", "yargs": "^17.7.2" }, "peerDependencies": { "@google-cloud/spanner": "^5.18.0 || ^6.0.0 || ^7.0.0 || ^8.0.0", "@sap/hana-client": "^2.14.22", "better-sqlite3": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0", "ioredis": "^5.0.4", "mongodb": "^5.8.0 || ^6.0.0", "mssql": "^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0", "mysql2": "^2.2.5 || ^3.0.1", "oracledb": "^6.3.0", "pg": "^8.5.1", "pg-native": "^3.0.0", "pg-query-stream": "^4.0.0", "redis": "^3.1.1 || ^4.0.0 || ^5.0.14", "sql.js": "^1.4.0", "sqlite3": "^5.0.3", "ts-node": "^10.7.0", "typeorm-aurora-data-api-driver": "^2.0.0 || ^3.0.0" }, "optionalPeers": ["@google-cloud/spanner", "@sap/hana-client", "better-sqlite3", "ioredis", "mongodb", "mssql", "mysql2", "oracledb", "pg", "pg-native", "pg-query-stream", "redis", "sql.js", "sqlite3", "ts-node", "typeorm-aurora-data-api-driver"], "bin": { "typeorm": "cli.js", "typeorm-ts-node-esm": "cli-ts-node-esm.js", "typeorm-ts-node-commonjs": "cli-ts-node-commonjs.js" } }, "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"husky": "^9.1.7",
 		"install": "^0.13.0",
 		"lint-staged": "^16.2.7",
-		"typescript": "5.9.3"
+		"typescript": "6.0.3"
 	},
 	"overrides": {
 		"axios": "^1.18.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"ignoreDeprecations": "6.0",
 		"baseUrl": ".",
 		"outDir": "./build",
 		"target": "ES2021",


### PR DESCRIPTION
## Summary

- Upgrade TypeScript **5.9.3 → 6.0.3** (latest stable), pinned exact.
- Add `ignoreDeprecations: "6.0"` to `tsconfig.json` for the two options
  TS6 deprecates ahead of TS7.

## Why now

The previous cap was `typescript-eslint`'s peer range (`<6.1.0`). After
migrating to Biome (PR #53), that constraint is gone, so TS6 is now
reachable.

## What TS6 reported

TS6 compiles the codebase with **zero type errors**. The only issues
were two deprecation warnings about `tsconfig` options being removed in
TS7:

- `baseUrl` (TS5101)
- `moduleResolution: "node"` / node10 (TS5107)

Both are silenced with `ignoreDeprecations: "6.0"`, the switch TypeScript
itself documents for the 6.0 transition. Actually migrating these
(`baseUrl` affects `src/...` imports; `node` → `bundler` for Bun) is a
separate modernization and out of scope here.

## Test plan

- [x] `bun run build` (tsc 6.0.3) — exit 0, no type errors
- [x] `bun test` — 246 pass / 0 fail
- [x] `bun run lint` (biome check) — exit 0
