### PR TITLE
feat(redis): connect to Redis at startup with shared client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,24 @@ import { cosmeticsDataSource } from "./cosmetics-data-source";
 import { PostgresTypeORM } from "./evolution-types/src/PostgresTypeORM";
 import { Server } from "./server/server";
 import { Pino } from "./shared/logger/infrastructure/Pino";
+import { redisClient } from "./shared/redis/redisClient";
 
 const logger = new Pino();
 
 void (async () => {
 	const database = new PostgresTypeORM();
-	await database.connect().catch((error) => logger.error(error));
-	await cosmeticsDataSource.initialize().catch((error) => logger.error(error));
+	await database
+		.connect()
+		.then(() => logger.info("Connected to Postgres (shared schema)"))
+		.catch((error) => logger.error(error));
+	await cosmeticsDataSource
+		.initialize()
+		.then(() => logger.info("Connected to Postgres (cosmetics schema)"))
+		.catch((error) => logger.error(error));
+	await redisClient
+		.connect()
+		.then(() => logger.info("Connected to Redis"))
+		.catch((error) => logger.error(error));
 	const server = new Server(logger);
 	server.start();
 })();

--- a/src/server/routes/ticket-router.ts
+++ b/src/server/routes/ticket-router.ts
@@ -1,15 +1,14 @@
 import { bearer } from "@elysiajs/bearer";
-import { RedisClient } from "bun";
 import { Elysia } from "elysia";
 
 import { config } from "../../config";
 import { IssueGameTicket } from "../../modules/ticket/application/IssueGameTicket";
 import { BunRedisRankedTicketRepository } from "../../modules/ticket/infrastructure/BunRedisRankedTicketRepository";
 import { JWT } from "../../shared/JWT";
+import { redisClient } from "../../shared/redis/redisClient";
 import { banGuard } from "../guards/bandGuard";
 
 const jwt = new JWT(config.jwt);
-const redisClient = new RedisClient(config.redis.url);
 const rankedTicketRepository = new BunRedisRankedTicketRepository(redisClient);
 
 export const ticketRouter = new Elysia({ prefix: "/game-tickets" })

--- a/src/shared/redis/redisClient.ts
+++ b/src/shared/redis/redisClient.ts
@@ -1,0 +1,8 @@
+import { RedisClient } from "bun";
+
+import { config } from "../../config";
+
+// Single shared Redis client for the whole app. Bun's RedisClient connects
+// lazily (on first command), so the boot sequence in src/index.ts calls
+// connect() explicitly to fail-fast if Redis is unreachable at startup.
+export const redisClient = new RedisClient(config.redis.url);


### PR DESCRIPTION
## What

Connect to Redis during the boot sequence and log successful connections to both Postgres datasources and Redis.

## Why

Bun's \`RedisClient\` connects lazily — on the first command. Before this change the Redis client was instantiated inside \`ticket-router.ts\` but never connected at startup, so a misconfigured or down Redis would only surface on the first \`POST /game-tickets\` request, not at boot.

## Changes

- **\`src/shared/redis/redisClient.ts\` (new):** extract the Redis client to a shared module-level singleton, consistent with how the Postgres datasources are wired. This ensures the startup check validates the *same* connection the ticket repository uses.
- **\`src/index.ts\`:** \`await redisClient.connect()\` in the boot sequence, following the existing Postgres pattern. Success logs added for both Postgres schemas and Redis via \`.then()\` (so the "Connected" log only prints on actual success, not when \`.catch\` swallows an error).
- **\`src/server/routes/ticket-router.ts\`:** reuse the shared client instead of creating its own.

## Notes

Keeps the existing **log-and-continue** error semantics (matches Postgres): a connection failure is logged but does not abort the process. This is detection-early, not strict fail-fast, intentionally consistent with the rest of the boot.